### PR TITLE
Small a11y tweak for language selectors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "identity-style-guide",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "The global style of login.gov",
   "main": "src/js/main.js",
   "scripts": {

--- a/src/css/components/_i18n-dropdown.scss
+++ b/src/css/components/_i18n-dropdown.scss
@@ -1,10 +1,5 @@
-#i18n-mobile-toggle,
-#i18n-desktop-toggle {
-  cursor: pointer;
-
-  &.focused .caret {
-    transform: rotateX(180deg) translateY(-1px);
-  }
+.focused .caret {
+  transform: rotateX(180deg) translateY(-1px);
 }
 
 #i18n-mobile-dropdown {
@@ -22,8 +17,11 @@
     border-radius:0;
     margin-bottom:0;
     margin-top:0;
-    padding-bottom: 12px;
-    padding-top: 12px;
+
+    & > a {
+      padding-bottom: 12px;
+      padding-top: 12px;
+    }
   }
 }
 


### PR DESCRIPTION
This supports changing the language selector into an actual link rather than a `div` acting as a link - which will be better for accessibility.