### PR TITLE
Add required css libraries as dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,29 +1,27 @@
 {
   "name": "identity-style-guide",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "The global style of login.gov",
   "main": "src/js/main.js",
   "files": [
     "src"
   ],
   "scripts": {
-    "build": "npm run build-css && npm run build-css-components && npm run build-font && npm run build-img && npm run compile-css && npm run copy-library-assets && npm run build-js && npm run compile-js",
     "build-css": "mkdir -p ./css && node-sass ./src/css/main.scss ./css/identity-style.css && npm run build-prefix",
-    "build-css-components": "node-sass ./src/css/base.scss ./css/base.css",
     "build-favicons": "mkdir -p ./favicons && npm run copy-favicons",
-    "build-font": "npm run copy-font",
+    "build-font": "mkdir -p ./fonts && npm run copy-font",
     "build-js": "mkdir -p ./js && browserify ./src/js/main.js -o ./js/identity-style.js",
     "build-prefix": "postcss --use autoprefixer css/identity-style.css -o ./css/identity-style.css",
     "build-img": "mkdir -p ./img && npm run copy-img",
     "build-library": "npm run build-library-assets && fractal build",
     "build-library-assets": "npm run clean && npm run build-css && npm run build-font && npm run build-favicons && npm run build-img && npm run copy-library-assets",
     "check-publish": "publish",
-    "clean": "rm -rf css/*.css && rm -rf img/* && rm -rf fonts/* && rm -rf js/* && rm -rf favicons/* && rm -rf docs/build",
+    "clean": "rm -rf css/* && rm -rf img/* && rm -rf fonts/* && rm -rf js/* && rm -rf favicons/* && rm -rf docs/build",
     "compile-css": "cleancss ./css/identity-style.css -o ./css/identity-style-min.css",
     "compile-js": "uglifyjs ./js/identity-style.js -o ./js/identity-style-min.js",
-    "copy-img": "cp -r node_modules/uswds/dist/img/*  img/ && cp ./src/img/* ./img",
+    "copy-img": "mkdir -p ./img && cp ./src/img/* ./img",
     "copy-favicons": "mkdir -p ./favicons && cp ./src/favicons/* ./favicons",
-    "copy-font": "mkdir -p ./fonts && cp node_modules/uswds/dist/fonts/* fonts/ && cp ./src/font/* ./fonts",
+    "copy-font": "mkdir -p ./fonts && cp ./src/font/* ./fonts",
     "copy-library-assets": "npm-run-all copy-library-assets-*",
     "copy-library-assets-css": "mkdir -p ./docs/assets/css && cp ./css/identity-style.css ./docs/src/main.css ./docs/assets/css",
     "copy-library-assets-favicons": "mkdir -p ./docs/assets/favicons && cp ./favicons/* ./docs/assets/favicons",
@@ -54,21 +52,22 @@
     "url": "https://github.com/18F/identity-style-guide/issues"
   },
   "homepage": "https://github.com/18F/identity-style-guide#readme",
+  "dependencies": {
+    "basscss-sass": "^3.0.0",
+    "normalize.css": "^4.2.0"
+  },
   "devDependencies": {
     "@18f/stylelint-rules": "^2.0.0",
     "@frctl/fractal": "^1.0.11",
     "@frctl/mandelbrot": "^1.0.7",
     "@frctl/nunjucks": "^1.0.2",
     "autoprefixer": "^6.6.1",
-    "basscss-sass": "^3.0.0",
     "browserify": "^13.3.0",
     "clean-css": "^3.4.23",
     "cross-spawn": "^4.0.0",
     "lodash.debounce": "^4.0.8",
     "node-sass": "^3.13.1",
-    "normalize.css": "^4.2.0",
     "npm-run-all": "^3.1.2",
-    "politespace": "^0.1.20",
     "postcss": "^5.2.10",
     "postcss-cli": "^2.3.3",
     "postcss-copy-assets": "^0.3.0",
@@ -76,7 +75,6 @@
     "prompt": "^1.0.0",
     "publish": "^0.6.0",
     "uglify-js": "^2.7.5",
-    "uswds": "~0.12.1",
     "watch": "^0.17.1"
   }
 }


### PR DESCRIPTION
Basscss and normalize.css are required for the rest of our stylesheets to work, so rather than relying on the companion site to have those listed as dependencies, always include them when this npm package is included.

Also removed some leftover dependencies and build scripts from cloning cloud.gov version.