### PR TITLE
Updates navigation to accommodate French

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "identity-style-guide",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "The global style of login.gov",
   "main": "src/js/main.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "identity-style-guide",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "The global style of login.gov",
   "main": "src/js/main.js",
   "files": [

--- a/src/css/components/static/_nav.scss
+++ b/src/css/components/static/_nav.scss
@@ -101,6 +101,25 @@ header nav {
     }
   }
 
+  // .lang-fr {
+  //   header nav {
+  //     .lang-nav-item {
+  //       margin-right: $space-2;
+  //     }
+  //   }
+  // }
+}
+
+
+@media #{$breakpoint-md}{
+  .lang-es {
+    header nav {
+      .lang-nav-item {
+        margin-right: $space-3;
+      }
+    }
+  }
+
   .lang-fr {
     header nav {
       .lang-nav-item {
@@ -110,9 +129,7 @@ header nav {
   }
 }
 
-
-@media #{$breakpoint-md}{
-  .lang-es,
+@media #{$breakpoint-lg}{
   .lang-fr {
     header nav {
       .lang-nav-item {

--- a/src/css/components/static/_nav.scss
+++ b/src/css/components/static/_nav.scss
@@ -1,4 +1,4 @@
-.logo { 
+.logo {
   line-height: 14px;
 
   img { height: 14px; }
@@ -44,11 +44,26 @@ header nav {
   }
 }
 
+.lang-es {
+  header nav {
+    .lang-nav-item {
+      margin-right: $space-2;
+    }
+  }
+}
+
+.lang-fr {
+  header nav {
+    .lang-nav-item {
+      margin-right: $space-1;
+    }
+  }
+}
 
 @media #{$breakpoint-sm} {
-  .logo { 
+  .logo {
     line-height: 17px;
-    
+
     img { height: 17px; }
   }
 
@@ -85,10 +100,35 @@ header nav {
       }
     }
   }
+
+  .lang-fr {
+    header nav {
+      .lang-nav-item {
+        margin-right: $space-2;
+      }
+    }
+  }
 }
 
-@media #{$breakpoint-es}{
+
+@media #{$breakpoint-md}{
+  .lang-es,
+  .lang-fr {
+    header nav {
+      .lang-nav-item {
+        margin-right: $space-3;
+      }
+    }
+  }
+}
+
+
+@media #{$breakpoint-lang}{
   header nav.es-nav {
-    font-size: $sm-es; 
+    font-size: $sm-lang;
+  }
+
+  header nav.fr-nav {
+    font-size: $sm-lang;
   }
 }

--- a/src/css/variables/_static.scss
+++ b/src/css/variables/_static.scss
@@ -33,7 +33,7 @@ $sm-h3: 1.125rem !default;
 $sm-h4: 1rem !default;
 $sm-h5: .875rem !default;
 $sm-h6: .8125rem !default;
-$sm-es: .74249rem !default;
+$sm-lang: .72rem !default;
 
 $space-tiny: .25rem !default;
 
@@ -101,7 +101,7 @@ $breakpoint-lg: '(min-width: 64em)' !default;
 $breakpoint-xl: '(min-width: 96em)' !default;
 $breakpoint-sm-md: '(min-width: 40em) and (max-width: 52em)' !default;
 $breakpoint-md-lg: '(min-width: 52em) and (max-width: 64em)' !default;
-$breakpoint-es: '(min-width: 736px) and (max-width: 775px)' !default;
+$breakpoint-lang: '(min-width: 736px) and (max-width: 775px)' !default;
 
 $container-width: 780px !default;
 $container-skinny-width: 620px !default;


### PR DESCRIPTION
For https://github.com/18F/identity-site/pull/158

Adds changes that prevent navigation items from wrapping over when the site is in French.

Bumps version to `0.2.8`