### PR TITLE
Introduce Circle CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,26 @@
+version: 2
+
+jobs:
+  build:
+    working_directory: ~/identity-style-guide
+    docker:
+      - image: circleci/ruby:2.5.3-node-browsers
+
+    steps:
+      - checkout
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package-lock.json" }}-{{ checksum "Gemfile.lock" }}
+      - run:
+          name: Install bundle dependencies
+          command: bundle check --path ~/.bundler || bundle install --path ~/.bundler
+      - run:
+          name: Install dependencies
+          command: npm ci
+      - save_cache:
+          key: dependency-cache-{{ checksum "package-lock.json" }}-{{ checksum "Gemfile.lock" }}
+          paths:
+            - ~/.npm
+            - ~/.bundler
+      - run:
+          name: Lint JavaScript and Sass
+          command: npm run lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}-{{ checksum "Gemfile.lock" }}
+          key: dependency-cache-v1-{{ checksum "package-lock.json" }}-{{ checksum "Gemfile.lock" }}
       - run:
           name: Install bundle dependencies
           command: bundle check --path ~/.bundler || bundle install --path ~/.bundler
@@ -17,7 +17,7 @@ jobs:
           name: Install dependencies
           command: npm ci
       - save_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}-{{ checksum "Gemfile.lock" }}
+          key: dependency-cache-v1-{{ checksum "package-lock.json" }}-{{ checksum "Gemfile.lock" }}
           paths:
             - ~/.npm
             - ~/.bundler


### PR DESCRIPTION
Currently only for running `npm run lint`, this will soon execute tests as well (once they’re written). 

I’ve run this locally with `circleci local execute --job build` to work out the kinks, so hopefully this should run well when Circle CI is enabled on this repo. 

- The installed gems (in `~/.bundler`) and npm’s cache (in `~/.npm`) are stored across runs to increase build speed (as [recommended by `npm ci`](https://docs.npmjs.com/cli/ci.html)).
- I’ve used `ruby:2.5.3-node-browsers` as a base image so we can easily run `jekyll` in the near future and spin up integration tests in headless Chrome.

<details>
<summary>Output of <code>circleci local execute --job build</code>.</summary>

```
➜ circleci local execute --job build

Docker image digest: sha256:7b3f88035e74739f72373aff135919f3a42cf59006b2832ec6293afdf727c5c1
====>> Spin up Environment
Build-agent version 0.1.1250-22bf9f5d (2018-12-12T11:32:15+0000)
Starting container circleci/ruby:2.5.3-node-browsers
  using image circleci/ruby@sha256:097f4bf109fc79905dbb90e6205030b5c11a6e0ce158d3c5997b4b180effb2cf

Using build environment variables:
  BASH_ENV=/tmp/.bash_env-localbuild-1545837754
  CI=true
  CIRCLECI=true
  CIRCLE_BRANCH=add-circleci-config
  CIRCLE_BUILD_NUM=
  CIRCLE_JOB=build
  CIRCLE_NODE_INDEX=0
  CIRCLE_NODE_TOTAL=1
  CIRCLE_REPOSITORY_URL=git@github.com:18F/identity-style-guide
  CIRCLE_SHA1=1d79286ad0f3c5bd8e07bd4284a033cb412ab79a
  CIRCLE_SHELL_ENV=/tmp/.bash_env-localbuild-1545837754
  CIRCLE_WORKING_DIRECTORY=~/identity-style-guide

====>> Checkout code
  #!/bin/bash -eo pipefail
mkdir -p /home/circleci/identity-style-guide && cp -r /tmp/_circleci_local_build_repo/. /home/circleci/identity-style-guide
====>> Restoring Cache
Error: 
Skipping cache - error checking storage: not supported


Step failed
====>> Install bundle dependencies
  #!/bin/bash -eo pipefail
bundle check --path ~/.bundler || bundle install --path ~/.bundler
The following gems are missing
 * public_suffix (3.0.2)
 * addressable (2.5.2)
 * colorator (1.1.0)
 * concurrent-ruby (1.0.5)
 * eventmachine (1.2.5)
 * http_parser.rb (0.6.0)
 * em-websocket (0.5.1)
 * ffi (1.9.23)
 * forwardable-extended (2.6.0)
 * i18n (0.9.5)
 * rb-fsevent (0.10.3)
 * rb-inotify (0.9.10)
 * sass-listen (4.0.0)
 * sass (3.5.5)
 * jekyll-sass-converter (1.5.2)
 * ruby_dep (1.5.0)
 * listen (3.1.5)
 * jekyll-watch (2.0.0)
 * kramdown (1.16.2)
 * liquid (4.0.0)
 * mercenary (0.3.6)
 * pathutil (0.16.1)
 * rouge (3.1.1)
 * safe_yaml (1.0.4)
 * jekyll (3.7.3)
Install missing gems with `bundle install`
Fetching gem metadata from https://rubygems.org/.............
Fetching public_suffix 3.0.2
Installing public_suffix 3.0.2
Fetching addressable 2.5.2
Installing addressable 2.5.2
Using bundler 1.17.2
Fetching colorator 1.1.0
Installing colorator 1.1.0
Fetching concurrent-ruby 1.0.5
Installing concurrent-ruby 1.0.5
Fetching eventmachine 1.2.5
Installing eventmachine 1.2.5 with native extensions
Fetching http_parser.rb 0.6.0
Installing http_parser.rb 0.6.0 with native extensions
Fetching em-websocket 0.5.1
Installing em-websocket 0.5.1
Fetching ffi 1.9.23
Installing ffi 1.9.23 with native extensions
Fetching forwardable-extended 2.6.0
Installing forwardable-extended 2.6.0
Fetching i18n 0.9.5
Installing i18n 0.9.5
Fetching rb-fsevent 0.10.3
Installing rb-fsevent 0.10.3
Fetching rb-inotify 0.9.10
Installing rb-inotify 0.9.10
Fetching sass-listen 4.0.0
Installing sass-listen 4.0.0
Fetching sass 3.5.5
Installing sass 3.5.5
Fetching jekyll-sass-converter 1.5.2
Installing jekyll-sass-converter 1.5.2
Fetching ruby_dep 1.5.0
Installing ruby_dep 1.5.0
Fetching listen 3.1.5
Installing listen 3.1.5
Fetching jekyll-watch 2.0.0
Installing jekyll-watch 2.0.0
Fetching kramdown 1.16.2
Installing kramdown 1.16.2
Fetching liquid 4.0.0
Installing liquid 4.0.0
Fetching mercenary 0.3.6
Installing mercenary 0.3.6
Fetching pathutil 0.16.1
Installing pathutil 0.16.1
Fetching rouge 3.1.1
Installing rouge 3.1.1
Fetching safe_yaml 1.0.4
Installing safe_yaml 1.0.4
Fetching jekyll 3.7.3
Installing jekyll 3.7.3
Bundle complete! 1 Gemfile dependency, 26 gems now installed.
Bundled gems are installed into `/home/circleci/.bundler`
====>> Install dependencies
  #!/bin/bash -eo pipefail
npm ci
npm WARN prepare removing existing node_modules/ before installation

> node-sass@4.11.0 install /home/circleci/identity-style-guide/node_modules/node-sass
> node scripts/install.js

Downloading binary from https://github.com/sass/node-sass/releases/download/v4.11.0/linux-x64-64_binding.node
Download complete
Binary saved to /home/circleci/identity-style-guide/node_modules/node-sass/vendor/linux-x64-64/binding.node
Caching binary to /home/circleci/.npm/node-sass/4.11.0/linux-x64-64_binding.node

> node-sass@4.11.0 postinstall /home/circleci/identity-style-guide/node_modules/node-sass
> node scripts/build.js

Binary found at /home/circleci/identity-style-guide/node_modules/node-sass/vendor/linux-x64-64/binding.node
Testing binary
Binary is fine

> fsevents@1.2.4 install /home/circleci/identity-style-guide/node_modules/fsevents
> node install


> identity-style-guide@0.2.6 postinstall /home/circleci/identity-style-guide
> make install-jekyll

gem list -i bundler || gem install bundler
true
bundle check || bundle install
The Gemfile's dependencies are satisfied
added 1472 packages in 28.589s
====>> Saving Cache
Error: 
Skipping cache - error checking storage: not supported

Step failed
====>> Lint JavaScript and Sass
  #!/bin/bash -eo pipefail
npm run lint

> identity-style-guide@0.2.6 lint /home/circleci/identity-style-guide
> make lint

./node_modules/.bin/gulp lint
[15:26:11] Using gulpfile ~/identity-style-guide/gulpfile.js
[15:26:11] Starting 'lint'...
[15:26:11] Starting 'lint-js'...
[15:26:11] Starting 'lint-sass'...
[15:26:12] Finished 'lint-js' after 731 ms
[15:26:13] Finished 'lint-sass' after 1.38 s
[15:26:13] Finished 'lint' after 1.38 s
Success!
```

</details>