### PR TITLE
Fix button conrast for secondary buttons.

### DIFF
--- a/src/scss/components/_buttons.scss
+++ b/src/scss/components/_buttons.scss
@@ -10,14 +10,14 @@
 
   &:hover,
   &.usa-button-hover {
-    background-color: color('primary-lighter');
+    background-color: color('primary-lightest');
     box-shadow: $button-stroke color('primary');
     color: color('primary');
   }
 
   &:active,
   &.usa-button-active {
-    background-color: color('primary-light');
+    background-color: color('primary-lighter');
     box-shadow: $button-stroke color('primary');
     color: color('primary');
   }

--- a/src/scss/uswds-theme/_color.scss
+++ b/src/scss/uswds-theme/_color.scss
@@ -65,7 +65,7 @@ $theme-color-base-darkest:          '#{$theme-color-base-family}-90';
 $theme-color-base-ink:              '#{$theme-color-base-family}-90';
 
 // Primary colors
-$theme-color-primary-lightest:      false;
+$theme-color-primary-lightest:      'site-input-blue';
 $theme-color-primary-lighter:       'site-light-blue';
 $theme-color-primary-light:         'site-med-blue';
 $theme-color-primary:               'site-blue';


### PR DESCRIPTION
Follow-up to #20.

My mistake here — I used the wrong shades of light blue when creating the secondary button styles which resulted in insufficient contrast.

| Before (bad) | After (good) |
|-------------|--------------|
| ![Screenshot of active buttons with insufficient contrast](https://user-images.githubusercontent.com/14930/50707088-c66b3c00-102d-11e9-98ca-3e4c3e4377fa.png) | ![Screenshot of active buttons with better contrast](https://user-images.githubusercontent.com/14930/50707044-a6d41380-102d-11e9-8391-42870dcccc13.png) |


Thanks to #21, when #20 was merged our [build failed due to insufficient contrast](https://circleci.com/gh/18F/identity-style-guide/15#artifacts/containers/0).