### PR TITLE
Introduce typography documentation and styles.

### DIFF
--- a/docs/_components/01-index.md
+++ b/docs/_components/01-index.md
@@ -2,21 +2,3 @@
 permalink: /components/
 title: Overview
 ---
-
-<p class="usa-font-lead">The page heading communicates the main focus of the page. Make your page heading descriptive and keep it succinct.</p>
-
-<h2 id="section-heading-h2">Section heading (h2)</h2>
-
-<p>These headings introduce, respectively, sections and subsections within your body copy. As you create these headings, follow the same guidelines that you use when writing section headings: Be succinct, descriptive, and precise.</p>
-
-<h3 id="section-heading-h3">Subsection heading (h3)</h3>
-
-<p>The particulars of your body copy will be determined by the topic of your page. Regardless of topic, it’s a good practice to follow the inverted pyramid structure when writing copy: Begin with the information that’s most important to your users and then present information of less importance.</p>
-
-<p>Keep each section and subsection focused — a good approach is to include one theme (topic) per section.</p>
-
-<h4 id="section-heading-h4">Subsection heading (h4)</h4>
-
-<p>Use the side navigation menu to help your users quickly skip to different sections of your page. The menu is best suited to displaying a hierarchy with one to three levels and, as we mentioned, to display the sub-navigation of a given page.</p>
-
-<p>Read the full documentation on our side navigation on the component page.</p>

--- a/docs/_components/buttons.md
+++ b/docs/_components/buttons.md
@@ -1,5 +1,7 @@
 ---
 title: Buttons
+lead: >
+  Use buttons to signal actions.
 subnav:
   - text: Standard Buttons
     href: "#standard-buttons"
@@ -21,13 +23,11 @@ subnav:
         href: "#tertiary"
 ---
 
-<p class="usa-font-lead">Use buttons to signal actions.</p>
-
-## Standard Buttons
+# Standard Buttons
 
 Use these button styles unless doing x and y, in which case, use [other buttons](#other-buttons).
 
-###### Primary
+##### Primary
 
 ```html
 <button class="usa-button">
@@ -39,7 +39,7 @@ Use these button styles unless doing x and y, in which case, use [other buttons]
 <button class="usa-button usa-focus">Focus</button>
 <button class="usa-button" disabled>Disabled</button>
 
-###### Secondary
+##### Secondary
 
 ```html
 <button class="usa-button usa-button-secondary">
@@ -51,7 +51,7 @@ Use these button styles unless doing x and y, in which case, use [other buttons]
 <button class="usa-button usa-button-secondary usa-focus">Focus</button>
 <button class="usa-button usa-button-secondary" disabled>Disabled</button>
 
-###### Success
+##### Success
 
 ```html
 <button class="usa-button usa-button-success">
@@ -63,7 +63,7 @@ Use these button styles unless doing x and y, in which case, use [other buttons]
 <button class="usa-button usa-button-success usa-focus">Focus</button>
 <button class="usa-button usa-button-success" disabled>Disabled</button>
 
-###### Danger
+##### Danger
 
 ```html
 <button class="usa-button usa-button-danger">
@@ -75,11 +75,11 @@ Use these button styles unless doing x and y, in which case, use [other buttons]
 <button class="usa-button usa-button-danger usa-focus">Focus</button>
 <button class="usa-button usa-button-danger" disabled>Disabled</button>
 
-## Other Buttons
+# Other Buttons
 
 These buttons should be used when x-ing and y-ing.
 
-###### Function
+##### Function
 
 ```html
 <button class="usa-button usa-button-inverse usa-button-small">
@@ -91,7 +91,7 @@ These buttons should be used when x-ing and y-ing.
 <button class="usa-button usa-button-inverse usa-button-small usa-focus">Focus</button>
 <button class="usa-button usa-button-inverse usa-button-small" disabled>Disabled</button>
 
-###### Tertiary
+##### Tertiary
 
 ```html
 <button class="usa-button usa-button-inverse usa-button-tiny">

--- a/docs/_components/form-fields.md
+++ b/docs/_components/form-fields.md
@@ -9,14 +9,14 @@ subnav:
     href: "#date-entry"
 ---
 
-## Form field groups
-## Form validation errors
-## Date entry
+# Form field groups
+# Form validation errors
+# Date entry
 
-## Radio
+# Radio
 
-### Small
+## Small
 
-### Normal
+## Normal
 
-### Large
+## Large

--- a/docs/_components/progress-indicators.md
+++ b/docs/_components/progress-indicators.md
@@ -7,6 +7,6 @@ subnav:
     href: "#indeterminite"
 ---
 
-## Determinite
+# Determinite
 
-## Indeterminite
+# Indeterminite

--- a/docs/_layouts/main.html
+++ b/docs/_layouts/main.html
@@ -22,14 +22,22 @@ layout: base
         </aside>
 
         <div class="usa-layout-docs-main_content desktop:grid-col-9 usa-prose">
-          <h1>{{ page.title }}</h1>
+          <div class="usa-display">{{ page.title }}</div>
+
+          {% if page.lead %}
+            <p class="usa-font-lead">{{ page.lead }}</p>
+          {% endif %}
 
           {{ content }}
         </div>
       </div>
     {% else %}
       <div class="usa-layout-docs-main_content usa-prose">
-        <h1>{{ page.title }}</h1>
+        <div class="usa-display">{{ page.title }}</div>
+
+        {% if page.lead %}
+          <p class="usa-font-lead">{{ page.lead }}</p>
+        {% endif %}
 
         {{ content }}
       </div>

--- a/docs/brand.md
+++ b/docs/brand.md
@@ -22,11 +22,11 @@ sidenav:
     href: "#illustration"
 ---
 
-## Logo
+# Logo
 
 Consistent and repeated use of the logo and lockups will establish equity and strengthen the visual identity of login.gov. To ensure consistency, it is critical that every person who uses the logo does so in accordance with the guidelines that follow, regardless of personal preference.
 
-### The shield and wordmark
+## The shield and wordmark
 
 The login.gov logo is the cornerstone of our brand. Whenever possible, the red and blue version should be used. A white (or reverse) version can be used on a dark background.
 
@@ -34,21 +34,21 @@ The login.gov logo is the cornerstone of our brand. Whenever possible, the red a
 
 <a href="{{ site.baseurl }}/assets/img/login-gov-logo-rev.svg" download><img src="{{ site.baseurl }}/assets/img/login-gov-logo-rev.svg" alt="login.gov logo" class="bg-primary-darker padding-4"></a>
 
-### Whitespace
+## Whitespace
 
 The logo should always be surrounded by generous white space. The diagram below defines the minimum amount of clear space needed, which is based on the cap-height of the typography.
 
 <img src="{{ site.baseurl }}/assets/img/style-guide/login-gov-logo-spacing.svg" alt="login.gov logo spacing diagram">
 
-### Minimum size
+## Minimum size
 
 Establishing a minimum size ensures that the impact and legibility of the logo is not compromised in application.
 
 <img src="{{ site.baseurl }}/assets/img/style-guide/login-gov-logo-minimum-size.svg" alt="login.gov logo minimum size diagram">
 
-## Logo usage
+# Logo usage
 
-### Incorrect color usage
+## Incorrect color usage
 
 For optimum legibility and brand consistency, the logo should never be used in white with a light background. Conversely, the standard logo should never appear on a dark background.
 
@@ -56,7 +56,7 @@ For optimum legibility and brand consistency, the logo should never be used in w
 
 <img src="{{ site.baseurl }}/assets/img/login-gov-logo.svg" alt="login.gov logo" class="bg-gray-70 padding-4">
 
-### Do not modify the logo
+## Do not modify the logo
 
 <div class="grid-row grid-gap">
   <div class="tablet:grid-col-4">
@@ -109,19 +109,19 @@ For optimum legibility and brand consistency, the logo should never be used in w
   </div>
 </div>
 
-## Illustration
+# Illustration
 
-### Principles
+## Principles
 
-#### Be useful
+### Be useful
 
 Illustration provides context, adds clarity, builds consistency, and lead users to their next step. Ultimately, any illustration should provide a deeper understanding of the application or brand.
 
-#### Be consistent
+### Be consistent
 
 Being consistent in illustration means considering details of a single illustration, as well as looking at the body of illustration work as a whole. Consistency speaks to quality: of the illustration and of the product it represents.
 
-#### Be focused
+### Be focused
 
 Illustration is most effective when it is precise in choosing a single message to deliver. With every narrative that is built there needs to be a focal point, a hierarchy of elements that contribute to the single, pointed message. With every illustration, we ask ourselves “what are we trying to say?”
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,14 +1,14 @@
 ---
 permalink: /
 title: Overview
+lead: >
+  Get up and running with the login.gov Design System in minutes. Or something catchy like that.
 sidenav:
   - text: Installation and usage
     href: "#installation-and-usage"
 ---
 
-<p class="usa-font-lead">Get up and running with the login.gov Design System in minutes. Or something catchy like that.</p>
-
-## Installation and usage
+# Installation and usage
 
 Install with `npm`:
 

--- a/docs/layout.md
+++ b/docs/layout.md
@@ -8,6 +8,6 @@ sidenav:
     href: "#spacing"
 ---
 
-## Grid
+# Grid
 
-## Spacing
+# Spacing

--- a/docs/typography.md
+++ b/docs/typography.md
@@ -1,21 +1,45 @@
 ---
 permalink: /typography/
 title: Typography
+lead: >
+  When writing longform text (a page like this), wrap the text in <code class="text-no-wrap text-secondary">div.usa-prose</code> to activate these styles.
 sidenav:
-  - text: Font stack
-    href: "#font-stack"
-  - text: Mobile vs. desktop
-    href: "#mobile-vs-desktop"
-  - text: Headings
-    href: "#headings"
-  - text: Body text
-    href: "#body-text"
+  - text: Display, headings, and lead
+    href: "#display-headings-and-lead"
 ---
 
-## Font stack
+# Display, headings, and lead
 
-## Mobile vs. desktop
+Use <code class="text-no-wrap text-secondary">div.usa-prose</code> to indicate that the immediately containing headings and paragraphs should be considered a longform text document:
 
-## Headings
+<div class="border-base-light border-left-1 padding-2 usa-prose">
+  <div class="usa-display">How login.gov keeps personal information private <span class="text-no-wrap text-secondary">(div.usa-display)</span></div>
 
-## Body text
+  <p class="usa-font-lead">login.gov encrypts the personal information of each user separately, using a unique value generated from each user’s password. Our encryption method works like a safe deposit box in a bank vault. Only the user has the key. Only the user can open the box to reveal the contents. Only the user knows the password, and only the user can decrypt their information. <span class="text-no-wrap text-secondary">(p.usa-font-lead)</span></p>
+
+  <h1>The vault <span class="text-no-wrap text-secondary">(h1)</span></h1>
+
+  <p>It’s hard to break into the “vault” or database. login.gov implements the latest National Institute of Standards and Technology (NIST) standards for secure authentication and verification. Our plans for ongoing security include regular penetration testing and external security reviews.</p>
+
+  <h2>The safe deposit box <span class="text-no-wrap text-secondary">(h2)</span></h2>
+
+  <p>Individual accounts get a double layer of security. We require two-factor authentication as well as strong passwords that meet new NIST requirements. Two factor authentication requires that you login with your password and a code that we send to your phone.</p>
+
+  <p>We will evaluate and implement new authentication methods as they become widely available to make sure that login.gov remains accessible and secure.</p>
+
+  <h3>Your personal key <span class="text-no-wrap text-secondary">(h3)</span></h3>
+
+  <p>Encrypting personal data separately means that login.gov cannot share any information with other government entities without users’ permission. Not even database administrators can decrypt a user’s personal information without the user’s password.</p>
+
+  <h4>Join us on GitHub <span class="text-no-wrap text-secondary">(h4)</span></h4>
+
+  <p>We welcome external review of our privacy-protection measures. All of our code is available for public inspection in an open-source repository. Our goal: make sure that at every step users know their privacy is being protected by design.</p>
+
+  <h5>More information on login.gov <span class="text-no-wrap text-secondary">(h5)</span></h5>
+
+  <p>For more information, please visit the login.gov Help Center or contact us. You can also visit our open-source repository.</p>
+
+  <h6>Simple and secure <span class="text-no-wrap text-secondary">(h6)</span></h6>
+
+  <p>Dedicated teams of design and security experts will continuously improve it.</p>
+</div>

--- a/src/scss/components/_typography.scss
+++ b/src/scss/components/_typography.scss
@@ -1,0 +1,65 @@
+.usa-prose {
+  @include add-knockout-font-smoothing;
+}
+
+.usa-prose > {
+  h1, h2, h3, h4 {
+    + * {
+      margin-top: 0.4em;
+    }
+  }
+
+  h1, h2, h3 {
+    letter-spacing: -0.2px;
+  }
+
+  h1 {
+    * + & {
+      margin-top: 1.9em;
+    }
+  }
+
+  h2, h3 {
+    * + & {
+      margin-top: 1.7em;
+    }
+  }
+  h4 {
+    letter-spacing: -0.1px;
+
+    * + & {
+      margin-top: 2.5em;
+    }
+  }
+  h5, h6 {
+    @include u-font-family('sans');
+    text-transform: uppercase;
+
+    * + & {
+      margin-top: 3em;
+    }
+    + * {
+      margin-top: 0.2em;
+    }
+  }
+  h5 {
+    letter-spacing: 0.2px;
+  }
+  h6 {
+    @include u-font-size('sans', 'micro');
+    @include u-font-weight('bold');
+    letter-spacing: 0.3px;
+  }
+}
+
+.usa-font-lead {
+  @include u-font-size('sans', 'md');
+
+  @include at-media('mobile-lg') {
+    @include u-font-size('sans', $theme-lead-font-size);
+  }
+}
+
+.usa-display {
+  @include typeset-h1;
+}

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -7,3 +7,4 @@
 @import 'uswds';
 
 @import 'components/buttons';
+@import 'components/typography';

--- a/src/scss/uswds-theme/_color.scss
+++ b/src/scss/uswds-theme/_color.scss
@@ -57,12 +57,12 @@ Theme palette colors
 $theme-color-base-family:           'gray';
 $theme-color-base-lightest:         '#{$theme-color-base-family}-5';
 $theme-color-base-lighter:          'gray-cool-10';
-$theme-color-base-light:            '#{$theme-color-base-family}-30';
-$theme-color-base:                  '#{$theme-color-base-family}-50';
+$theme-color-base-light:            'site-light-grey';
+$theme-color-base:                  'site-grey';
 $theme-color-base-dark:             'gray-cool-60';
 $theme-color-base-darker:           'gray-cool-80';
 $theme-color-base-darkest:          '#{$theme-color-base-family}-90';
-$theme-color-base-ink:              '#{$theme-color-base-family}-90';
+$theme-color-base-ink:              'site-grey';
 
 // Primary colors
 $theme-color-primary-lightest:      'site-input-blue';
@@ -75,14 +75,13 @@ $theme-color-primary-darker:        'site-navy';
 $theme-color-primary-darkest:       false;
 
 // Secondary colors
-$theme-color-secondary-family:      'red';
 $theme-color-secondary-lightest:    false;
-$theme-color-secondary-lighter:     '#{$theme-color-secondary-family}-10';
-$theme-color-secondary-light:       '#{$theme-color-secondary-family}-30';
-$theme-color-secondary:             '#{$theme-color-secondary-family}-50';
-$theme-color-secondary-vivid:       '#{$theme-color-secondary-family}-50v';
-$theme-color-secondary-dark:        '#{$theme-color-secondary-family}-60v';
-$theme-color-secondary-darker:      '#{$theme-color-secondary-family}-70v';
+$theme-color-secondary-lighter:     false;
+$theme-color-secondary-light:       'site-pink';
+$theme-color-secondary:             'site-red';
+$theme-color-secondary-vivid:       false;
+$theme-color-secondary-dark:        'site-dark-red';
+$theme-color-secondary-darker:      'site-darkest-red';
 $theme-color-secondary-darkest:     false;
 
 // Accent warm colors

--- a/src/scss/uswds-theme/_typography.scss
+++ b/src/scss/uswds-theme/_typography.scss
@@ -37,7 +37,7 @@ Accepts true or false
 ----------------------------------------
 */
 
-$theme-respect-user-font-size: true;
+$theme-respect-user-font-size: false;
 
 // $theme-root-font-size only applies when
 // $theme-respect-user-font-size is set to
@@ -49,7 +49,7 @@ $theme-respect-user-font-size: true;
 
 // Accepts values in px
 
-$theme-root-font-size: 10px;
+$theme-root-font-size: 16px;
 
 /*
 ----------------------------------------
@@ -197,13 +197,13 @@ values from the USWDS system type scale
 ----------------------------------------
 */
 
-$theme-type-scale-3xs:      2;
+$theme-type-scale-3xs:      'micro';
 $theme-type-scale-2xs:      3;
 $theme-type-scale-xs:       4;
 $theme-type-scale-sm:       5;
 $theme-type-scale-md:       6;
 $theme-type-scale-lg:       9;
-$theme-type-scale-xl:       12;
+$theme-type-scale-xl:       11;
 $theme-type-scale-2xl:      14;
 $theme-type-scale-3xl:      15;
 
@@ -284,22 +284,22 @@ none:    none
 
 // Body settings are the equivalent of setting the <body> element
 $theme-body-font-family:           'body';
-$theme-body-font-size:             'sm';
+$theme-body-font-size:             'xs';
 $theme-body-line-height:           5;
 
 // If true, explicitly style the <body> element with the base styles
 $theme-style-body-element:         false;
 
 // Headings
-$theme-h1-font-size:               '2xl';
-$theme-h2-font-size:               'xl';
-$theme-h3-font-size:               'lg';
-$theme-h4-font-size:               'sm';
-$theme-h5-font-size:               'xs';
+$theme-h1-font-size:               'xl';
+$theme-h2-font-size:               'lg';
+$theme-h3-font-size:               'md';
+$theme-h4-font-size:               'xs';
+$theme-h5-font-size:               '2xs';
 $theme-h6-font-size:               '3xs';
-$theme-heading-line-height:        2;
+$theme-heading-line-height:        3;
 $theme-small-font-size:            '2xs';
-$theme-title-font-size:            '3xl';
+$theme-title-font-size:            '2xl';
 
 // Text and prose
 $theme-text-measure-narrow:        1;
@@ -308,7 +308,7 @@ $theme-text-measure-wide:          4;
 $theme-prose-font-family:          'body';
 
 // Lead text
-$theme-lead-font-family:           'heading';
-$theme-lead-font-size:             'lg';
+$theme-lead-font-family:           'body';
+$theme-lead-font-size:             8;
 $theme-lead-line-height:           6;
 $theme-lead-measure:               5;


### PR DESCRIPTION
This introduces typography documentation, the related styles, and updates the existing documentation pages to use the typography styles as required. 

There are minor variances in size and spacing as compared to the Sketch document — I opted to follow the U.S. Web Design System’s font sizing tools instead of setting exact sizing.

It feels like there should be more documentation here, but I’m not sure anything else is required for implementing these styles. Maybe some documentation about when to use `.usa-prose` and when not to? 

[![Screenshot of typography documentation page](https://user-images.githubusercontent.com/14930/50711882-988df380-103d-11e9-9ca3-3988c9cacef0.png)](https://federalist-proxy.app.cloud.gov/preview/18f/identity-style-guide/typography/typography/)