### PR TITLE
Remove tmp directory when cleaning.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 MAKEFLAGS += --jobs=6
+TMP_DIR = ./tmp
 OUTPUT_DIR = ./dist
 
 # Federalist builds overwrite the output directory.
@@ -55,3 +56,4 @@ test-runner-pa11y:
 
 clean:
 	rm -rf $(OUTPUT_DIR)
+	rm -rf $(TMP_DIR)


### PR DESCRIPTION
A follow-up to #21.

Test results are written to a temporary directory — we should clean that when running `npm run clean`.