### PR TITLE
Add Color documentation.

### DIFF
--- a/docs/_includes/helpers/color.html
+++ b/docs/_includes/helpers/color.html
@@ -1,0 +1,9 @@
+<div class="tablet:grid-col margin-bottom-2">
+  <div class="bg-{{ include.code }} text-{{ include.text-color }} display-flex flex-align-end flex-justify-end padding-1 margin-bottom-05 width-full height-card">
+    <code>{{ include.hex }}</code>
+  </div>
+  <div class="margin-right-1">
+    <strong>{{ include.name }}</strong><br>
+    <code>{{ include.code }}</code>
+  </div>
+</div>

--- a/docs/color.md
+++ b/docs/color.md
@@ -2,3 +2,151 @@
 permalink: /color/
 title: Color
 ---
+
+# Main palette
+
+<div class="grid-row grid-gap">
+  {% include helpers/color.html
+    name="Navy"
+    code="primary-darker"
+    hex="#112e51"
+    text-color="white"
+  %}
+  {% include helpers/color.html
+    name="Blue"
+    code="primary"
+    hex="#0071bb"
+    text-color="white"
+  %}
+  {% include helpers/color.html
+    name="Light Blue"
+    code="primary-lighter"
+    hex="#ebf3fa"
+    text-color="black"
+  %}
+  {% include helpers/color.html
+    name="Red"
+    code="secondary"
+    hex="#e21c3d"
+    text-color="white"
+  %}
+</div>
+
+# Extended palette
+
+<div class="grid-row grid-gap">
+  <div class="grid-row tablet:grid-col">
+    {% include helpers/color.html
+      name="Dark Blue"
+      code="primary-dark"
+      hex="#205493"
+      text-color="white"
+    %}
+    {% include helpers/color.html
+      name="Medium Blue"
+      code="primary-light"
+      hex="#cedced"
+      text-color="black"
+    %}
+    {% include helpers/color.html
+      name="Input Blue"
+      code="primary-lightest"
+      hex="#f2f9ff"
+      text-color="black"
+    %}
+  </div>
+  <div class="grid-row tablet:grid-col">
+    {% include helpers/color.html
+      name="Teal"
+      code="accent-cool"
+      hex="#00bfe7"
+      text-color="black"
+    %}
+    {% include helpers/color.html
+      name="Light Teal"
+      code="accent-cool-light"
+      hex="#ecfcff"
+      text-color="black"
+    %}
+  </div>
+</div>
+
+<div class="grid-row grid-gap">
+  <div class="grid-row tablet:grid-col">
+    {% include helpers/color.html
+      name="Darkest Green"
+      code="success-darker"
+      hex="#094316"
+      text-color="white"
+    %}
+    {% include helpers/color.html
+      name="Dark Green"
+      code="success-dark"
+      hex="#116523"
+      text-color="white"
+    %}
+    {% include helpers/color.html
+      name="Green"
+      code="success"
+      hex="#18852e"
+      text-color="white"
+    %}
+    {% include helpers/color.html
+      name="Light Green"
+      code="success-lighter"
+      hex="#ebfcef"
+      text-color="black"
+    %}
+  </div>
+  <div class="grid-row tablet:grid-col">
+    {% include helpers/color.html
+      name="Gray"
+      code="base"
+      hex="#5b616a"
+      text-color="white"
+    %}
+    {% include helpers/color.html
+      name="Light Gray"
+      code="base-light"
+      hex="#dddfe4"
+      text-color="black"
+    %}
+  </div>
+</div>
+
+<div class="grid-row grid-gap">
+  <div class="grid-row tablet:grid-col">
+    {% include helpers/color.html
+      name="Darkest Red"
+      code="secondary-darker"
+      hex="#8b0a21"
+      text-color="white"
+    %}
+    {% include helpers/color.html
+      name="Dark Red"
+      code="secondary-dark"
+      hex="#ab142f"
+      text-color="white"
+    %}
+    {% include helpers/color.html
+      name="Pink"
+      code="secondary-light"
+      hex="#fff0f3"
+      text-color="black"
+    %}
+  </div>
+  <div class="grid-row tablet:grid-col">
+    {% include helpers/color.html
+      name="Yellow"
+      code="warning"
+      hex="#f5d600"
+      text-color="black"
+    %}
+    {% include helpers/color.html
+      name="Light Yellow"
+      code="warning-light"
+      hex="#fffdd7"
+      text-color="black"
+    %}
+  </div>
+</div>

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -6,5 +6,13 @@
 
 @import 'uswds';
 
+// https://github.com/uswds/uswds/issues/2894
+.bg-success-darker { background-color: color('success-darker'); }
+.bg-success-dark { background-color: color('success-dark'); }
+.bg-success { background-color: color('success'); }
+.bg-success-lighter { background-color: color('success-lighter'); }
+.bg-warning { background-color: color('warning'); }
+.bg-warning-light { background-color: color('warning-light'); }
+
 @import 'components/buttons';
 @import 'components/typography';

--- a/src/scss/uswds-theme/_color.scss
+++ b/src/scss/uswds-theme/_color.scss
@@ -98,8 +98,8 @@ $theme-color-accent-warm-darkest:   false;
 $theme-color-accent-cool-family:    'cyan';
 $theme-color-accent-cool-lightest:  false;
 $theme-color-accent-cool-lighter:   '#{$theme-color-accent-cool-family}-5';
-$theme-color-accent-cool-light:     '#{$theme-color-accent-cool-family}-20';
-$theme-color-accent-cool:           '#{$theme-color-accent-cool-family}-30v';
+$theme-color-accent-cool-light:     'site-light-teal';
+$theme-color-accent-cool:           'site-teal';
 $theme-color-accent-cool-dark:      '#{$theme-color-accent-cool-family}-40v';
 $theme-color-accent-cool-darker:    'blue-60';
 $theme-color-accent-cool-darkest:   false;
@@ -121,18 +121,17 @@ $theme-color-error-darker:     '#{$theme-color-error-family}-70v';
 // Warning colors
 $theme-color-warning-family:   'gold';
 $theme-color-warning-lighter:  '#{$theme-color-warning-family}-5v';
-$theme-color-warning-light:    '#{$theme-color-warning-family}-10v';
-$theme-color-warning:          '#{$theme-color-warning-family}-20v';
+$theme-color-warning-light:    'site-light-yellow';
+$theme-color-warning:          'site-yellow';
 $theme-color-warning-dark:     '#{$theme-color-warning-family}-30v';
 $theme-color-warning-darker:   '#{$theme-color-warning-family}-40v';
 
 // Success colors
-$theme-color-success-family:   'green-cool';
-$theme-color-success-lighter:  '#{$theme-color-success-family}-5';
-$theme-color-success-light:    '#{$theme-color-success-family}-30v';
-$theme-color-success:          '#{$theme-color-success-family}-40v';
-$theme-color-success-dark:     '#{$theme-color-success-family}-50';
-$theme-color-success-darker:   '#{$theme-color-success-family}-70';
+$theme-color-success-lighter:  'site-light-green';
+$theme-color-success-light:    false;
+$theme-color-success:          'site-green';
+$theme-color-success-dark:     'site-dark-green';
+$theme-color-success-darker:   'site-darkest-green';
 
 // Info colors
 $theme-color-info-family:      'cyan';


### PR DESCRIPTION
This PR adds the Color documentation page. In the process, I uncovered what I believe to be a bug in the US Web Design System, reported at https://github.com/uswds/uswds/issues/2894. I implemented a temporary workaround in this PR. 

[![Screenshot of new Color page](https://user-images.githubusercontent.com/14930/50798736-6253ac80-12a7-11e9-8bb5-dae877671b86.png)](https://federalist-proxy.app.cloud.gov/preview/18f/identity-style-guide/color/color/)


