### PR TITLE
Add basic code highlighting.

### DIFF
--- a/src/scss/components/_code.scss
+++ b/src/scss/components/_code.scss
@@ -1,0 +1,73 @@
+// stylelint-disable declaration-block-single-line-max-declarations
+
+pre,
+code {
+  @include u-font('mono', $theme-body-font-size);
+}
+
+.highlight .hll { background-color: color('base-lightest'); }
+.highlight { background: color('white'); }
+.highlight .c { color: color('base'); font-style: italic; } /* comment */
+.highlight .err { color: color('error-lighter'); background-color: color('error'); } /* error */
+.highlight .k { color: color('primary-dark'); } /* keyword */
+.highlight .ch { color: color('base'); font-style: italic; } /* comment.hashbang */
+.highlight .cm { color: color('base'); font-style: italic; } /* comment.multiline */
+.highlight .cp { color: color('success'); } /* comment.preproc */
+.highlight .cpf { color: color('base'); font-style: italic; } /* comment.preprocfile */
+.highlight .c1 { color: color('base'); font-style: italic; } /* comment.single */
+.highlight .cs { color: color('primary-dark'); font-style: italic; } /* comment.special */
+.highlight .gd { color: color('secondary-dark'); } /* generic.deleted */
+.highlight .ge { font-style: italic; } /* generic.emph */
+.highlight .gr { color: color('secondary-dark'); } /* generic.error */
+.highlight .gh { font-weight: bold; } /* generic.heading */
+.highlight .gi { color: color('primary-darker'); } /* generic.inserted */
+.highlight .go { color: color('base'); } /* generic.output */
+.highlight .gp { color: color('base'); } /* generic.prompt */
+.highlight .gs { font-weight: bold; } /* generic.strong */
+.highlight .gu { font-weight: bold; } /* generic.subheading */
+.highlight .gt { color: color('secondary-dark'); } /* generic.traceback */
+.highlight .kc { color: color('primary-dark'); } /* keyword.constant */
+.highlight .kd { color: color('primary-dark'); } /* keyword.declaration */
+.highlight .kn { color: color('primary-dark'); } /* keyword.namespace */
+.highlight .kp { color: color('primary-dark'); } /* keyword.pseudo */
+.highlight .kr { color: color('primary-dark'); } /* keyword.reserved */
+.highlight .kt { color: color('secondary'); } /* keyword.type */
+.highlight .m { color: color('accent-cool-dark'); } /* literal.number */
+.highlight .s { color: color('secondary-dark'); } /* literal.string */
+.highlight .na { color: color('primary'); } /* name.attribute */
+.highlight .nb { color: color('secondary'); } /* name.builtin */
+.highlight .nc { color: color('primary-darker'); text-decoration: underline; } /* name.class */
+.highlight .no { color: color('secondary-dark'); } /* name.constant */
+.highlight .nd { color: color('base'); } /* name.decorator */
+.highlight .ni { font-weight: bold; } /* name.entity */
+.highlight .nf { color: color('primary-darker'); } /* name.function */
+.highlight .nn { color: color('secondary'); text-decoration: underline; } /* name.namespace */
+.highlight .nt { color: color('primary'); font-weight: bold; } /* name.tag */
+.highlight .nv { color: color('secondary-dark'); } /* name.variable */
+.highlight .ow { color: color('primary-dark'); } /* operator.word */
+.highlight .w { color: color('base-light'); } /* text.whitespace */
+.highlight .mb { color: color('accent-cool-dark'); } /* literal.number.bin */
+.highlight .mf { color: color('accent-cool-dark'); } /* literal.number.float */
+.highlight .mh { color: color('accent-cool-dark'); } /* literal.number.hex */
+.highlight .mi { color: color('accent-cool-dark'); } /* literal.number.integer */
+.highlight .mo { color: color('accent-cool-dark'); } /* literal.number.oct */
+.highlight .sa { color: color('secondary-dark'); } /* literal.string.affix */
+.highlight .sb { color: color('secondary-dark'); } /* literal.string.backtick */
+.highlight .sc { color: color('secondary-dark'); } /* literal.string.char */
+.highlight .dl { color: color('secondary-dark'); } /* literal.string.delimiter */
+.highlight .sd { color: color('secondary-dark'); } /* literal.string.doc */
+.highlight .s2 { color: color('secondary-dark'); } /* literal.string.double */
+.highlight .se { color: color('secondary-dark'); } /* literal.string.escape */
+.highlight .sh { color: color('secondary-dark'); } /* literal.string.heredoc */
+.highlight .si { color: color('secondary-dark'); } /* literal.string.interpol */
+.highlight .sx { color: color('secondary-dark'); } /* literal.string.other */
+.highlight .sr { color: color('accent-cool-dark'); } /* literal.string.regex */
+.highlight .s1 { color: color('secondary-dark'); } /* literal.string.single */
+.highlight .ss { color: color('primary-dark'); } /* literal.string.symbol */
+.highlight .bp { color: color('secondary'); } /* name.builtin.pseudo */
+.highlight .fm { color: color('primary-darker'); } /* name.function.magic */
+.highlight .vc { color: color('secondary-dark'); } /* name.variable.class */
+.highlight .vg { color: color('secondary-dark'); } /* name.variable.global */
+.highlight .vi { color: color('secondary-dark'); } /* name.variable.instance */
+.highlight .vm { color: color('secondary-dark'); } /* name.variable.magic */
+.highlight .il { color: color('accent-cool-dark'); } /* literal.number.integer.long */

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -17,4 +17,5 @@
 @import 'components/accordions';
 @import 'components/alerts';
 @import 'components/buttons';
+@import 'components/code';
 @import 'components/typography';


### PR DESCRIPTION
As mentioned in #27, this implements basic code highlighting styles, based off the login.gov color space. These are pygments compatible class names, which are the standard across every standard syntax highlighter.

Additionally, this PR applies the theme monospace font (Roboto Mono Web) to all `code` and `pre` elements for convenience and compatibility with default markdown syntax highlighting.

Here’s what it looks like on the Accordions page:

[![Screenshot of Accordions documentation page](https://user-images.githubusercontent.com/14930/51327169-b6e0ef80-1a3e-11e9-8040-d34ab46fc37b.png)](https://federalist-proxy.app.cloud.gov/preview/18f/identity-style-guide/code-styles/components/accordions/)

I didn’t spend an incredible amount of time on this, so open to changes and iterations as we discover what doesn’t work.
