### PR TITLE
Adjust tooltip documentation, styles.

### DIFF
--- a/docs/_components/tooltips.md
+++ b/docs/_components/tooltips.md
@@ -1,80 +1,63 @@
 ---
 title: Tooltips
 lead: >
-  Tooltips are used to display help text to the user in an unobtrusive way
+  Tooltips are used to display help text to the user in an unobtrusive way.
 ---
 
-Tooltips can be useful means to display information to a user, most typically in forms, without adding
-clutter to the visual presentation of your user experience.
+Tooltips can be useful means to display information to a user, most typically in forms, without adding clutter to the visual presentation of your user experience.
 
-Before using a tooltip, it is important to consider if the information the tooltip is intended to convey
-makes more sense as a label for a given form field or section.
+**Before using a tooltip,** it is important to consider if the information the tooltip is intended to convey makes more sense as a label for a given form field or section.
 
-All tooltips must include a `tabindex` and `aria-label` property. This ensures that the tooltips display correctly
-to the user and can be triggered by a mouse, keyboard, or assistive device. When using a mouse, tooltips can be triggered
-by hovering, or clicking in the case of a mobile device.
-
-All tooltips require the `tooltip` class to function, additional classes are used to control the tooltip's position.
-The `usa-tooltip-large` class can also be used to control the width of the tooltip bubble.
-
-For all options, see the code examples below.
-
+**All tooltips must include a `tabindex` and `aria-label` property.** This ensures that the tooltips display correctly to the user and can be triggered by a mouse, keyboard, or assistive device. Tooltips can be triggered by hovering when using a mouse, tapping in the case of a mobile device, or focusing by tab key.
 
 ## Using the tooltip with an icon
 
-{% capture icon-tip %}
-<span class="usa-tooltip usa-tooltip-top usa-tooltip-large" aria-label="this tooltip includes an icon" tabindex="0">
-  <img src="{{ site.baseurl }}/assets/img/tooltip.svg" width="16" height="16" class="text-middle" alt="tooltip help icon" />
+{% capture example %}
+<span class="usa-tooltip usa-tooltip-top" aria-label="Hello there! You look nice today." tabindex="0">
+  <img src="{{ site.baseurl }}/assets/img/tooltip.svg" width="16" height="16" class="text-middle" alt="Help icon" />
 </span>
 {% endcapture %}
+{% include helpers/code-example.html code=example %}
 
-{{ icon-tip }}
+## Large tooltips
 
+Add the class `.usa-tooltip-large` to enhance!
 
-```html
-{{ icon-tip }}
-```
+{% capture example %}
+<div class="usa-tooltip usa-tooltip-top usa-tooltip-large bg-primary-lightest padding-1" aria-label="Four score and seven years ago our fathers brought forth on this continent, a new nation, conceived in Liberty, and dedicated to the proposition that all [folks] are created equal." tabindex="0">
+  This element has a lot of tooltip text.
+</div>
+{% endcapture %}
+{% include helpers/code-example.html code=example %}
 
-## Decorating other elements with a tooltip
+## Positioning tooltips
 
 As long as the proper classes are applied, any HTML element can be decorated with a tooltip.
 
-{% capture tip-top %}
-<a class="usa-tooltip usa-tooltip-top" aria-label="top tip" tabindex="0" href="#">
-  top-aligned tooltip
-</a>
+{% capture example %}
+<div class="usa-tooltip usa-tooltip-top bg-primary-lightest padding-1" aria-label="Right here, in fact." tabindex="0">
+  This element has a tooltip above it.
+</div>
 {% endcapture %}
+{% include helpers/code-example.html code=example %}
 
-
-{% include helpers/code-example.html code=tip-top %}
-<br/>
-
-{% capture tip-left %}
-<p class="usa-tooltip usa-tooltip-left" aria-label="left tip" tabindex="0">
-  left-aligned tooltip
-</p>
+{% capture example %}
+<div class="usa-tooltip usa-tooltip-left bg-primary-lightest padding-1" aria-label="Everything you own in the box to the left!" tabindex="0">
+  This element has a tooltip to the left of it.
+</div>
 {% endcapture %}
+{% include helpers/code-example.html code=example %}
 
-{{ tip-left }}
-{% include helpers/code-example.html code=tip-left %}
-<br/>
-
-{% capture tip-bottom %}
-<p class="usa-tooltip usa-tooltip-bottom" aria-label="bottom tip" tabindex="0">
-  bottom-aligned tooltip
-</p>
+{% capture example %}
+<div class="usa-tooltip usa-tooltip-bottom bg-primary-lightest padding-1" aria-label="Down low! ✋" tabindex="0">
+  This element has a tooltip below it.
+</div>
 {% endcapture %}
+{% include helpers/code-example.html code=example %}
 
-{{ tip-bottom }}
-{% include helpers/code-example.html code=tip-bottom %}
-<br/>
-
-{% capture tip-right %}
-<p class="usa-tooltip usa-tooltip-right" aria-label="right tip" tabindex="0">
-  right-aligned tooltip
-</p>
+{% capture example %}
+<div class="usa-tooltip usa-tooltip-right bg-primary-lightest padding-1" aria-label="… I ran out of jokes." tabindex="0">
+  This element has a tooltip to the right of it.
+</div>
 {% endcapture %}
-
-{{ tip-right }}
-{% include helpers/code-example.html code=tip-right %}
-<br/>
+{% include helpers/code-example.html code=example %}

--- a/src/scss/components/_tooltips.scss
+++ b/src/scss/components/_tooltips.scss
@@ -1,3 +1,6 @@
+$tooltip-arrow-size: 8px;
+$tooltip-distance: units(.5);
+
 .usa-tooltip {
   cursor: help;
   display: inline-block;
@@ -9,37 +12,32 @@
 
   // the triangle
   &::before {
-    border-width: 8px 8px 0 8px;
+    border-width: $tooltip-arrow-size $tooltip-arrow-size 0 $tooltip-arrow-size;
     border-style: solid;
     border-color: color('primary') transparent transparent transparent;
     content: '';
     display: block;
     height: 0;
-    left: 5%;
     opacity: 0;
     position: absolute;
-    top: 5px;
-    transform: translateX(-50%);
     width: 0;
   }
 
   // the bubble
   &::after {
     @include u-radius('md');
-    @include u-width('15');
+    @include u-width('card');
 
     background-color: color('primary');
     color: color('white');
     content: attr(aria-label);
     font-size: $theme-h6-font-size;
-    left: 50%;
     line-height: 1.3;
     opacity: 0;
-    padding: 10px;
+    padding: units(1);
     pointer-events: none;
     position: absolute;
     text-align: center;
-    transform: translateX(-50%) translateY(-100%);
     white-space: normal;
   }
 
@@ -52,61 +50,73 @@
   }
 
   &.usa-tooltip-top {
-    &:before,
+    &:before {
+      left: 50%;
+      top: -$tooltip-distance;
+      transform: translate(-50%, -100%);
+    }
+
     &:after {
       left: 50%;
-      top: -50%;
+      top: calc(-#{$tooltip-arrow-size} - #{$tooltip-distance});
+      transform: translate(-50%, -100%);
     }
   }
 
   &.usa-tooltip-left {
     &:before {
-      left: -15%;
+      left: -$tooltip-distance;
       top: 50%;
-      transform: translateY(-50%) rotate(-90deg);
+      transform: translate(-100%, -50%);
+      border-width: $tooltip-arrow-size 0 $tooltip-arrow-size $tooltip-arrow-size;
+      border-style: solid;
+      border-color: transparent transparent transparent color('primary');
     }
 
     &:after {
-      left: -10%;
+      left: calc(-#{$tooltip-arrow-size} - #{$tooltip-distance});
       top: 50%;
-      transform: translateX(-100%) translateY(-50%);
+      transform: translate(-100%, -50%);
     }
   }
 
   &.usa-tooltip-right {
     &:before {
-      left: 100%;
-      transform: translateY(50%) rotate(90deg);
+      right: -$tooltip-distance;
+      top: 50%;
+      transform: translate(100%, -50%);
+      border-width: $tooltip-arrow-size $tooltip-arrow-size $tooltip-arrow-size 0;
+      border-style: solid;
+      border-color: transparent color('primary') transparent transparent;
     }
 
     &:after {
-      @include u-margin-left('105');
-
-      left: 100%;
+      right: calc(-#{$tooltip-arrow-size} - #{$tooltip-distance});
       top: 50%;
-      transform: translateY(-50%);
+      transform: translate(100%, -50%);
     }
   }
 
   &.usa-tooltip-bottom {
-    &:before, &:after {
-      @include u-margin-top(1);
-      top: 100%;
-    }
-
     &:before {
       left: 50%;
-      transform: translateX(-50%) translateY(-100%) rotate(-180deg);
+      bottom: -$tooltip-distance;
+      transform: translate(-50%, 100%);
+      border-width: 0 $tooltip-arrow-size $tooltip-arrow-size $tooltip-arrow-size;
+      border-style: solid;
+      border-color: transparent transparent color('primary') transparent;
     }
 
     &:after {
-      transform: translateX(-50%) translateY(0%);
+      left: 50%;
+      bottom: calc(-#{$tooltip-arrow-size} - #{$tooltip-distance});
+      transform: translate(-50%, 100%);
     }
   }
 
   &.usa-tooltip-large {
     &:after {
-      @include u-width('card');
+      @include u-width('card-lg');
     }
   }
 }


### PR DESCRIPTION
A follow-up to #48.

These styles were previously using percentage units relative to the size of the element the tooltip was attached to, which didn’t work very well when I adjusted the size of the container the tooltip was attached to. 

This PR switches the units to avoid positioning errors as the source element changes size. 

Additionally, using `transform: rotate()` causes some style issues, as the coordinate plane is also rotated. I found it to be more straightforward to adjust the border size instead. 