### PR TITLE
Add max-width to list items, remove bottom margin.

### DIFF
--- a/docs/typography.md
+++ b/docs/typography.md
@@ -39,4 +39,10 @@ Use <code class="text-no-wrap text-secondary">div.usa-prose</code> to indicate t
   <h6>Simple and secure <span class="text-no-wrap text-secondary">(h6)</span></h6>
 
   <p>Dedicated teams of design and security experts will continuously improve it.</p>
+
+  <ul>
+    <li>We welcome external review of our privacy-protection measures. All of our code is available for public inspection in an open-source repository. Our goal: make sure that at every step users know their privacy is being protected by design.</li>
+    <li>For more information, please visit the login.gov Help Center or contact us. You can also visit our open-source repository.</li>
+    <li>Dedicated teams of design and security experts will continuously improve it.</li>
+  </ul>
 </div>

--- a/src/scss/components/_typography.scss
+++ b/src/scss/components/_typography.scss
@@ -50,6 +50,17 @@
     @include u-font-weight('bold');
     letter-spacing: 0.3px;
   }
+
+  // https://github.com/uswds/uswds/pull/2906
+  ol, ul {
+    &:last-child {
+      margin-bottom: 0;
+    }
+
+    li {
+      max-width: measure($theme-text-measure);
+    }
+  }
 }
 
 .usa-font-lead {


### PR DESCRIPTION
Fixes #54.

Two list tweaks:

1. Adds a max-width to list items.
2. Removes the bottom margin from `<ul>` and `<ol>` elements when they are the last item in a container, to prevent excess bottom space (see screenshot).

Additionally, it adds lists to the Typography documentation page, so we can observe the changes:

| Before | After |
|-------|-------|
| ![Screenshot of list items which do not have maximum width constraints and have extra margin-bottom](https://user-images.githubusercontent.com/14930/52427435-e4650a00-2acd-11e9-8702-0ffef9149e2e.png) | ![Screenshot of list items which are constrained by a maximum width, and do not contain extra margin-bottom](https://user-images.githubusercontent.com/14930/52427332-c8616880-2acd-11e9-9f8b-ce5e5b945d0f.png) |
