### PR TITLE
Include state utility classes by enabling them in the U.S. Web Design System.

### DIFF
--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -8,15 +8,6 @@
 
 @import 'uswds';
 
-// https://github.com/uswds/uswds/issues/2894
-.bg-success-darker { background-color: color('success-darker'); }
-.bg-success-dark { background-color: color('success-dark'); }
-.bg-success { background-color: color('success'); }
-.bg-success-lighter { background-color: color('success-lighter'); }
-.bg-warning { background-color: color('warning'); }
-.bg-warning-light { background-color: color('warning-light'); }
-.bg-disabled { background-color: color('disabled'); }
-
 @import 'functions/focus';
 
 @import 'components/accordions';

--- a/src/scss/uswds-theme/_utilities.scss
+++ b/src/scss/uswds-theme/_utilities.scss
@@ -55,7 +55,8 @@ The following palettes will be added to
 */
 
 $global-color-palettes: (
-  'palette-color-default'
+  'palette-color-default',
+  'palette-color-state'
 );
 
 /*


### PR DESCRIPTION
Fixes https://github.com/uswds/uswds/issues/2894.

This setting enables state utility classes (for example, `.bg-success`), which makes the state style declarations redundant.