### PR TITLE
Code styles

### DIFF
--- a/docs/_includes/helpers/code-example.html
+++ b/docs/_includes/helpers/code-example.html
@@ -2,6 +2,6 @@
 
 <div markdown="1">
 ```html
-{{ include.code | replace_regex: '\s?data-test(?:="[^\s"]+")', '' }}
+{{ include.code | strip | replace_regex: '\s?data-test(?:="[^\s"]+")', '' }}
 ```
 </div>

--- a/docs/_includes/helpers/color.html
+++ b/docs/_includes/helpers/color.html
@@ -1,6 +1,6 @@
-<div class="tablet:grid-col margin-bottom-2">
-  <div class="bg-{{ include.code }} text-{{ include.text-color }} display-flex flex-align-end flex-justify-end padding-1 margin-bottom-05 width-full height-card" data-test="color-swatch">
-    <code>{{ include.hex }}</code>
+<div class="tablet:grid-col margin-bottom-4">
+  <div class="bg-{{ include.code }} display-flex flex-align-end flex-justify-end padding-1 margin-bottom-1 width-full height-card" data-test="color-swatch">
+    <code class="bg-transparent text-{{ include.text-color }}">{{ include.hex }}</code>
   </div>
   <div class="margin-right-1">
     <strong>{{ include.name }}</strong><br>

--- a/docs/typography.md
+++ b/docs/typography.md
@@ -2,12 +2,12 @@
 permalink: /typography/
 title: Typography
 lead: >
-  When writing longform text (a page like this), wrap the text in <code class="text-no-wrap text-secondary">div.usa-prose</code> to activate these styles.
+  When writing longform text (a page like this), wrap the text in <code class="text-no-wrap">div.usa-prose</code> to activate these styles.
 ---
 
 # Display, headings, and lead
 
-Use <code class="text-no-wrap text-secondary">div.usa-prose</code> to indicate that the immediately containing headings and paragraphs should be considered a longform text document:
+Use <code class="text-no-wrap">div.usa-prose</code> to indicate that the immediately containing headings and paragraphs should be considered a longform text document:
 
 <div class="border-base-light border-left-1 padding-2 usa-prose">
   <div class="usa-display">How login.gov keeps personal information private <span class="text-no-wrap text-secondary">(div.usa-display)</span></div>

--- a/src/scss/components/_code.scss
+++ b/src/scss/components/_code.scss
@@ -1,12 +1,65 @@
 // stylelint-disable declaration-block-single-line-max-declarations
 
+$inline-border-radius: border-radius('sm');
+$inline-background-color: #f7f7f7;
+$block-border-radius: $inline-border-radius;
+$block-background-color: #fafafa;
+$block-border-width: 1px;
+$block-padding-width: units(2);
+
 pre,
 code {
   @include u-font('mono', $theme-body-font-size);
+  color: color('ink');
+}
+
+code {
+  // Override font size to use em so it adjusts appropriately to match nearby text.
+  font-size: .89309em;
+  padding: 2px 3px;
+  background-color: $inline-background-color;
+  border-radius: $inline-border-radius;
+}
+
+pre {
+  @include u-border($block-border-width, 'gray-5');
+  border-radius: $block-border-radius;
+  background-color: $block-background-color;
+  padding: $block-padding-width;
+
+  code {
+    font-size: unset;
+    background-color: transparent;
+  }
+}
+
+.highlight {
+  position: relative;
+
+  &::before,
+  &::after {
+    content: '';
+    display: block;
+    position: absolute;
+    z-index: 1;
+    top: $block-border-width;
+    bottom: $block-border-width;
+    width: $block-padding-width;
+    border-radius: $block-border-radius;
+  }
+
+  &::before {
+    left: $block-border-width;
+    background-image: linear-gradient(to left, transparent, $block-background-color);
+  }
+
+  &::after {
+    right: $block-border-width;
+    background-image: linear-gradient(to right, transparent, $block-background-color);
+  }
 }
 
 .highlight .hll { background-color: color('base-lightest'); }
-.highlight { background: color('white'); }
 .highlight .c { color: color('base'); font-style: italic; } /* comment */
 .highlight .err { color: color('error-lighter'); background-color: color('error'); } /* error */
 .highlight .k { color: color('primary-dark'); } /* keyword */

--- a/src/scss/components/_tooltips.scss
+++ b/src/scss/components/_tooltips.scss
@@ -8,6 +8,7 @@ $tooltip-distance: units(.5);
 
   &::before, &::after {
     visibility: hidden;
+    z-index: 1;
   }
 
   // the triangle


### PR DESCRIPTION
Fixes #56.

This PR changes inline and block code samples to use a gray background, which helps distinguish it from the surrounding text: 

| Before | After | 
|-------|-------|
| ![Screenshot showing no background color on code or pre elements](https://user-images.githubusercontent.com/14930/52492461-3cb40e80-2b97-11e9-8619-9b5411844448.png) | ![Screenshot showing gray background color on code or pre elements](https://user-images.githubusercontent.com/14930/52492423-2a39d500-2b97-11e9-96cb-cc88ee299b7f.png) |

Because this introduces bottom padding on block code samples, it also addresses the scrollbar issue discussed in #56:

![Screenshot showing that the scrollbar no longer overlaps content](https://user-images.githubusercontent.com/14930/52492625-8c92d580-2b97-11e9-9271-16bcbf02c58c.png)
