### PR TITLE
Adjust focus color, shape.

### DIFF
--- a/src/scss/components/_buttons.scss
+++ b/src/scss/components/_buttons.scss
@@ -1,3 +1,9 @@
+.usa-button:focus,
+.usa-button.usa-focus {
+  @include disable-default-focus-styles;
+  box-shadow: roundable-focus-outline-box-shadows();
+}
+
 .usa-button-secondary,
 .usa-button-outline {
   background-color: color('white');
@@ -8,17 +14,20 @@
     color: color('primary');
   }
 
+  &:focus,
+  &.usa-focus {
+    box-shadow: $button-stroke color('primary'), roundable-focus-outline-box-shadows();
+  }
+
   &:hover,
   &.usa-button-hover {
     background-color: color('primary-lightest');
-    box-shadow: $button-stroke color('primary');
     color: color('primary');
   }
 
   &:active,
   &.usa-button-active {
     background-color: color('primary-lighter');
-    box-shadow: $button-stroke color('primary');
     color: color('primary');
   }
 

--- a/src/scss/components/_inputs.scss
+++ b/src/scss/components/_inputs.scss
@@ -9,6 +9,11 @@ $border-width: 1px;
   background-color: color('primary-lightest');
   border-radius: radius('md');
 
+  &:focus {
+    @include disable-default-focus-styles;
+    box-shadow: roundable-focus-outline-box-shadows();
+  }
+
   &.usa-input-error {
     @include u-border($border-width, 'error');
     background-position: right units($input-padding) center;
@@ -26,6 +31,11 @@ $border-width: 1px;
   @include add-background-svg('arrow-down-filled');
   font-weight: font-weight('bold');
   border-radius: radius('md');
+
+  &:focus {
+    @include disable-default-focus-styles;
+    box-shadow: roundable-focus-outline-box-shadows();
+  }
 
   &.usa-input-error {
     @include u-border($border-width, 'error');
@@ -81,6 +91,20 @@ $border-width: 1px;
 
 .usa-checkbox-input:checked + .usa-checkbox-label::before {
   box-shadow: inset 0 0 0 units($border-width) color('primary');
+}
+
+.usa-radio-input:checked:focus + .usa-radio-label::before {
+  @include disable-default-focus-styles;
+  box-shadow: inset 0 0 0 0.3rem color('primary'), roundable-focus-outline-box-shadows();
+}
+
+.usa-checkbox-input:focus + .usa-checkbox-label::before {
+  @include disable-default-focus-styles;
+  box-shadow: inset 0 0 0 units($border-width) color('primary'), roundable-focus-outline-box-shadows();
+}
+
+.usa-checkbox-input:checked:focus + .usa-checkbox-label::before {
+  box-shadow: roundable-focus-outline-box-shadows();
 }
 
 .usa-radio-bordered,

--- a/src/scss/functions/_focus.scss
+++ b/src/scss/functions/_focus.scss
@@ -1,0 +1,9 @@
+@mixin disable-default-focus-styles {
+  outline: none;
+}
+
+@function roundable-focus-outline-box-shadows {
+  @return
+    0 0 0 $theme-focus-offset color('white'),
+    0 0 0 $theme-focus-width + $theme-focus-offset color($theme-focus-color);
+}

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -15,6 +15,8 @@
 .bg-warning-light { background-color: color('warning-light'); }
 .bg-disabled { background-color: color('disabled'); }
 
+@import 'functions/focus';
+
 @import 'components/accordions';
 @import 'components/alerts';
 @import 'components/banner';

--- a/src/scss/uswds-theme/_general.scss
+++ b/src/scss/uswds-theme/_general.scss
@@ -74,10 +74,10 @@ Focus styles
 ----------------------------------------
 */
 
-$theme-focus-color:  'blue-40v';
-$theme-focus-offset: 0;
+$theme-focus-color:  'primary';
+$theme-focus-offset: 1px;
 $theme-focus-style:  solid;
-$theme-focus-width:  0.5;
+$theme-focus-width:  2px;
 
 /*
 ----------------------------------------


### PR DESCRIPTION
Fixes #57.

This PR uses the login.gov color palette for focus rectangles. Additionally, for inputs with rounded edges, uses box shadows instead of outlines to follow the input’s visible edges.

The new styles are based on the existing styles for secure.login.gov:

![Existing styles on secure.login.gov](https://user-images.githubusercontent.com/14930/52578923-31f5b580-2df3-11e9-8486-959bef6ad703.png)

Here’s what the new styles in this PR look like:

| Before | After |
|-------|-------|
| ![Screenshot of primary navigation before focus style changes](https://user-images.githubusercontent.com/14930/52577895-1db0b900-2df1-11e9-80d8-4189416d750c.png) | ![Screenshot of primary navigation after focus style changes](https://user-images.githubusercontent.com/14930/52578353-1211c200-2df2-11e9-9e32-78ffaa2018b7.png) |
| ![Screenshot of sidebar navigation before focus style changes](https://user-images.githubusercontent.com/14930/52578080-7aac6f00-2df1-11e9-8a25-b21098d98b17.png) | ![Screenshot of sidebar navigation after focus style changes](https://user-images.githubusercontent.com/14930/52578397-2786ec00-2df2-11e9-9ef9-d3d040bc78c3.png) |
| ![Screenshot of link focus style before focus style changes](https://user-images.githubusercontent.com/14930/52578111-8c8e1200-2df1-11e9-82fd-a5b83f41124d.png) | ![Screenshot of link focus style after focus style changes](https://user-images.githubusercontent.com/14930/52578584-77fe4980-2df2-11e9-9ff3-89583cc8fee8.png) |
| ![Screenshot of button styles before focus style changes](https://user-images.githubusercontent.com/14930/52578169-ab8ca400-2df1-11e9-90c1-aaf4d849b3ea.png) | ![Screenshot of button styles after focus style changes](https://user-images.githubusercontent.com/14930/52578631-9106fa80-2df2-11e9-8708-81046873b0f3.png)| 
| ![Screenshot of text inputs before focus style changes](https://user-images.githubusercontent.com/14930/52578204-bba48380-2df1-11e9-95df-8bde6df05825.png) | ![Screenshot of text inputs after focus style changes](https://user-images.githubusercontent.com/14930/52578673-b431aa00-2df2-11e9-91a8-e0299e2dd612.png) |
| ![Screenshot of radio button inputs before focus style changes](https://user-images.githubusercontent.com/14930/52578238-d119ad80-2df1-11e9-92c0-9b163c44c896.png) | ![Screenshot of radio button inputs after focus style changes](https://user-images.githubusercontent.com/14930/52578699-c4498980-2df2-11e9-96f4-529062e9be77.png) |
| ![Screenshot of checkboxes before focus style changes](https://user-images.githubusercontent.com/14930/52578265-e4c51400-2df1-11e9-9bad-f5c7bc687a27.png) | ![Screenshot of checkboxes after focus style changes](https://user-images.githubusercontent.com/14930/52578731-d1ff0f00-2df2-11e9-8781-d6772bd20a9e.png) |
