### PR TITLE
Extract usage instructions to page; add plugin.

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -1,4 +1,5 @@
 primary:
+  - href: /usage/
   - href: /brand/
   - href: /typography/
   - href: /color/

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,17 +9,18 @@ lead: >
 <section class="usa-section usa-section-dark">
   <div class="grid-container">
     <div class="grid-row">
-      <div class="maxw-tablet usa-prose">
+      <div class="maxw-tablet">
         <div class="usa-display">
           The key to a strong brand <br>is <span class="text-accent-cool">consistency</span>.
         </div>
         <p class="usa-font-lead">{{ page.lead }}</p>
+        <a href="{{ site.baseurl }}/usage/" class="usa-button usa-button-big">See usage instructions</a>
       </div>
     </div>
   </div>
 </section>
 
-<section class="usa-section usa-section-light">
+<section class="usa-section">
   <div class="grid-container">
     <div class="grid-row grid-gap-4">
       <div class="tablet:grid-col">
@@ -49,38 +50,6 @@ The latest version is <strong class="text-no-wrap">{{ site.package_json.this_ver
 
 </div>
       </div>
-    </div>
-  </div>
-</section>
-
-<section class="usa-section">
-  <div class="grid-container">
-    <div class="grid-row grid-gap-4">
-<div class="grid-col usa-prose" markdown="1">
-
-# Using the {{ site.title }}
-
-First, install the latest version using npm:
-
-```shell
-npm install identity-style-guide
-```
-
-If this is your first npm dependency, a `package-lock.json` file will be generated. Commit this file to source control.
-
-The module is now installed at `./node_modules/identity-style-guide`. Woohoo!
-
-## Compiled CSS, JavaScript, fonts, and images
-
-You’ll find the compiled assets in `dist/assets`. These are ready to be used in your project directly.
-
-We recommend including these files from `node_modules` directly, either by linking to them at that location or by copying them automatically during a build process, to make upgrades easier in the future.
-
-## Uncompiled Sass and next-generation JavaScript
-
-The original source files in Sass and next-generation JavaScript are in `src`. Use these files if your project will be extending styles or JavaScript — but you’ll need to compile them in your build pipeline using a Sass compiler and a next-generation JavaScript compiler like Babel.
-
-</div>
     </div>
   </div>
 </section>

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,74 @@
+---
+permalink: /usage/
+title: Usage
+lead: >
+  Install images, stylesheets, and script files in both their original and compiled forms with npm.
+---
+
+```shell
+npm install identity-style-guide
+```
+
+If this is your first npm dependency, a `package-lock.json` file will be generated. Commit this file to source control.
+
+The module is now installed at `./node_modules/identity-style-guide`. Woohoo!
+
+# Precompiled CSS, JavaScript, fonts, and images
+
+You’ll find the compiled assets in `dist/assets`. These are ready to be used in your project directly.
+
+<div class="usa-alert usa-alert-warning usa-alert-paragraph">
+  <div class="usa-alert-body">
+    <p class="usa-alert-text" markdown="1">The paths in the compiled CSS file assume that your asset folders follow the same structure as those in `dist/assets`. Copy this folder in its entirety, or compile the assets from source as described below.</p>
+  </div>
+</div>
+
+We recommend including these files from `node_modules` directly, either by linking to them at that location or by copying them automatically during a build process, to make upgrades easier in the future.
+
+## Copy during Jekyll build process
+
+If you’re using Jekyll, a simple plugin can help copy this file during your build process to keep your assets up-to-date. First, add this file to `_plugins/`:
+
+```ruby
+# _plugins/copy_to_destination.rb
+
+module Jekyll
+  module CopyToDestination
+    class CopyGenerator < Generator
+      def generate(site)
+        folders = site.config['copy_to_destination'] || []
+
+        static_files = folders.map do |relative_path|
+          absolute_path = File.join(site.source, relative_path)
+          folder_path = File.dirname(absolute_path)
+          entries = Dir.glob(File.join(absolute_path, '**', '*'))
+          files = entries.select { |f| File.file?(f) }
+
+          files.map do |file|
+            relative_directory = File.dirname(file).sub(folder_path, '')
+            filename = File.basename(file)
+            StaticFile.new(site, folder_path, relative_directory, filename)
+          end
+        end.flatten
+
+        site.static_files.concat(static_files)
+      end
+    end
+  end
+end
+```
+
+Then, configure it to copy the compiled assets to your site output folder:
+
+```yaml
+# _config.yml
+
+copy_to_destination:
+  - node_modules/identity-style-guide/dist/assets
+```
+
+# Compiling source files in your build process
+
+The original source files in Sass and next-generation JavaScript are in `src`.
+
+Use these files if your project will be extending styles or JavaScript — but you’ll need to compile them in your build pipeline using a Sass compiler and a next-generation JavaScript compiler like Babel.


### PR DESCRIPTION
Adds the Jekyll plugin used in https://github.com/18F/identity-dev-docs/pull/67 as a reference to the usage instructions, and moves the usage instructions to its own page.

I’ll follow-up this PR with extended usage instructions for the **Compiling source files in your build process** section, after I’ve done a basic integration that does so.

[![Screenshot of usage instructions](https://user-images.githubusercontent.com/14930/52582902-48ecd580-2dfc-11e9-8a7a-b28ac544c80c.png)](https://federalist-proxy.app.cloud.gov/preview/18f/identity-style-guide/documentation-updates/usage/)
