### PR TITLE
Simplify usage of scss within Rails.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-dist
-node_modules
-tmp
+/dist
+/node_modules
+/tmp
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ build: build-docs build-assets
 build-docs:
 	JEKYLL_ENV=production bundle exec jekyll build
 
-build-assets: build-sass-and-js build-fonts build-images
+build-assets: build-sass-and-js build-fonts build-images copy-scss
 
 build-sass-and-js:
 	NODE_ENV=production \
@@ -45,6 +45,9 @@ build-images:
 	mkdir -p $(OUTPUT_DIR)/assets/img
 	cp -r node_modules/uswds/src/img $(OUTPUT_DIR)/assets
 	cp -r src/img $(OUTPUT_DIR)/assets
+
+copy-scss:
+	./node_modules/.bin/gulp copy-scss
 
 test: build
 	make test-runners

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -67,8 +67,32 @@ copy_to_destination:
   - node_modules/identity-style-guide/dist/assets
 ```
 
-# Compiling source files in your build process
+# Compiling Sass in your build process
 
-The original source files in Sass and next-generation JavaScript are in `src`.
+Use the original source scss files if your project will be extending styles — but you’ll need to compile them in your build pipeline using a Sass compiler. The source scss files can be found in `dist/assets/scss`, and can be imported into your project’s scss files in one import:
 
-Use these files if your project will be extending styles or JavaScript — but you’ll need to compile them in your build pipeline using a Sass compiler and a next-generation JavaScript compiler like Babel.
+```scss
+@import 'node_modules/identity-style-guide/dist/assets/scss/styles';
+```
+
+## Use with Rails
+
+The scss files natively support `asset-path()` out-of-the-box for ease of use with the Rails Asset Pipeline. To use with Rails, configure Rails to look for assets in both `node_modules` and the identity-style-guide module:
+
+```ruby
+# config/initializers/assets.rb
+
+Rails.application.config.assets.paths << Rails.root.join('node_modules')
+Rails.application.config.assets.paths << Rails.root.join('node_modules/identity-style-guide/dist/assets')
+```
+
+Finally, import the styles into your main stylesheet:
+
+```scss
+// app/assets/stylesheets/application.css.scss
+
+$font-path: 'fonts';
+$image-path: 'img';
+
+@import 'identity-style-guide/dist/assets/scss/styles';
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -5610,6 +5610,12 @@
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
     },
+    "fork-stream": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/fork-stream/-/fork-stream-0.0.4.tgz",
+      "integrity": "sha1-24Sfznf2cIpfjzhq5TOgkHtUrnA=",
+      "dev": true
+    },
     "form-data": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
@@ -6874,6 +6880,26 @@
             "extend-shallow": "^3.0.2"
           }
         }
+      }
+    },
+    "gulp-if": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.2.tgz",
+      "integrity": "sha1-pJe351cwBQQcqivIt92jyARE1ik=",
+      "dev": true,
+      "requires": {
+        "gulp-match": "^1.0.3",
+        "ternary-stream": "^2.0.1",
+        "through2": "^2.0.1"
+      }
+    },
+    "gulp-match": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.3.tgz",
+      "integrity": "sha1-kcfA1/Kb7NZgbVfYCn+Hdqh6uo4=",
+      "dev": true,
+      "requires": {
+        "minimatch": "^3.0.3"
       }
     },
     "gulp-notify": {
@@ -16659,6 +16685,18 @@
         }
       }
     },
+    "ternary-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
+      "integrity": "sha1-Bk5Im0tb9gumpre8fy9cJ07Pgmk=",
+      "dev": true,
+      "requires": {
+        "duplexify": "^3.5.0",
+        "fork-stream": "^0.0.4",
+        "merge-stream": "^1.0.0",
+        "through2": "^2.0.1"
+      }
+    },
     "test-exclude": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.3.tgz",
@@ -17875,7 +17913,7 @@
       }
     },
     "uswds-gulp": {
-      "version": "github:uswds/uswds-gulp#743929a4617bea25ca8267f9e2323f8c976419eb",
+      "version": "github:uswds/uswds-gulp#888a8f69b1a08ce55636820ce4fb4bcec32aa55d",
       "from": "github:uswds/uswds-gulp",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -15,9 +15,7 @@
     "prepublishOnly": "make lint && make clean && make build-assets"
   },
   "files": [
-    "dist/assets/**/*",
-    "src/js/**/*",
-    "src/scss/**/*"
+    "dist/assets/**/*"
   ],
   "repository": {
     "type": "git",
@@ -50,6 +48,7 @@
     "get-port-cli": "^2.0.0",
     "gulp": "^4.0.0",
     "gulp-eslint": "^5.0.0",
+    "gulp-if": "^2.0.2",
     "gulp-notify": "^3.2.0",
     "gulp-postcss": "^8.0.0",
     "gulp-rename": "^1.4.0",

--- a/src/scss/functions/_asset-path.scss
+++ b/src/scss/functions/_asset-path.scss
@@ -1,0 +1,17 @@
+/*
+----------------------------------------
+asset-path-if-exists()
+----------------------------------------
+Defines a no-op function, which does not
+override a previous definition, to look
+up asset paths (Rails).
+----------------------------------------
+*/
+
+@function asset-path-if-exists($path) {
+  @if function-exists(asset-path) {
+    @return asset-path($path);
+  }
+
+  @return $path;
+}

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -1,3 +1,5 @@
+@import 'functions/asset-path';
+
 @import 'uswds-theme/general';
 @import 'uswds-theme/typography';
 @import 'uswds-theme/spacing';

--- a/src/scss/uswds-theme/_general.scss
+++ b/src/scss/uswds-theme/_general.scss
@@ -25,8 +25,8 @@ Relative font and image file paths
 ----------------------------------------
 */
 
-$theme-font-path:   '../fonts';
-$theme-image-path:  '../img';
+$theme-font-path: if(variable-exists(font-path), $font-path, '../fonts');
+$theme-image-path: if(variable-exists(image-path), $image-path, '../img');
 
 /*
 ----------------------------------------

--- a/test/dist/scss.test.js
+++ b/test/dist/scss.test.js
@@ -1,0 +1,42 @@
+const path = require('path');
+const util = require('util');
+const { compiler } = require('gulp-sass');
+
+test('scss files can be imported without node_modules', async () => {
+  const results = await util.promisify(compiler.render)({
+    data: "@import 'assets/scss/styles';",
+    includePaths: [
+      path.resolve(__dirname, '../../dist'),
+    ],
+  });
+
+  expect(results.css.toString('utf-8')).toMatch(/\.usa-/);
+});
+
+test('if an asset-path function is defined, it is used to generate asset paths with $image-path and $font-path', async () => {
+  const results = await util.promisify(compiler.render)({
+    data: `
+      @function asset-path($path) {
+        @return 'test-path-rewritten/' + $path;
+      }
+
+      $font-path: 'test-fonts';
+      $image-path: 'test-img';
+
+      @import 'assets/scss/styles';
+    `,
+    includePaths: [
+      path.resolve(__dirname, '../../dist'),
+    ],
+  });
+
+  const css = results.css.toString('utf-8');
+
+  const [usaAlertWarning] = css.match(/\.usa-alert-warning\s?{[^}]+}/);
+  const [usaInputError] = css.match(/\.usa-textarea\.usa-input-error:not\(\.usa-input-inline\)\s?{[^}]+}/);
+  const [fontFace] = css.match(/@font-face\s?{[^}]+}/);
+
+  expect(usaAlertWarning).toMatch(/test-path-rewritten\/test-img/);
+  expect(usaInputError).toMatch(/test-path-rewritten\/test-img/);
+  expect(fontFace).toMatch(/test-path-rewritten\/test-fonts/);
+});


### PR DESCRIPTION
This PR makes extending the source Sass files easier within any project, and especially easy within Rails projects.

- The source Sass files are copied over to `dist/assets/scss`, including the `uswds` dependency. The paths used within the style guide to include `uswds` are rewritten to reference the local folder, so no dependency issues will appear when this library is used in another build pipeline.
- Anytime `url([something])` is encountered, it is wrapped in `url(asset-path-if-defined([something]))`. The `asset-path-if-defined()` function passes through the path unchanged, unless the `asset-path()` function is also defined (as it is [within the Rails Asset Pipeline](https://guides.rubyonrails.org/asset_pipeline.html#css-and-sass)).
- The `$font-path` and `$img-path` variables are now exposed, which control where fonts and images are referenced from (before they are passed into `asset-path()`, if it is defined). 

The result is a straightforward import from Sass, and transparent support for the Rails Asset Pipeline, as demonstrated in the documentation update:

[![image](https://user-images.githubusercontent.com/14930/52672351-9c8a1c80-2eeb-11e9-886b-ecc51677eae3.png)](https://federalist-proxy.app.cloud.gov/preview/18f/identity-style-guide/src-include-improvements/usage/)
