### PR TITLE
Remove elements hidden from accessibility tests.

### DIFF
--- a/.pa11yci.js
+++ b/.pa11yci.js
@@ -5,10 +5,5 @@ module.exports = {
     },
     "concurrency": 10,
     "standard": "WCAG2AA",
-    "hideElements": [
-      // https://github.com/18F/identity-style-guide/issues/49
-      ".usa-radio__input:disabled + .usa-radio__label",
-      ".usa-checkbox-input:disabled + .usa-checkbox-label"
-    ].join()
   }
 }


### PR DESCRIPTION
Now that #49 is fixed, we can remove these exceptions from the tests. :tada: