### PR TITLE
Create a page for content style guide

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -1,6 +1,7 @@
 primary:
   - href: /usage/
   - href: /brand/
+  - href: /content/
   - href: /typography/
   - href: /color/
   - href: /layout/

--- a/docs/content.md
+++ b/docs/content.md
@@ -29,32 +29,29 @@ Reference the [18F content principles](https://content-guide.18f.gov/content-pri
 
 Login.gov’s voice is&hellip;
 
-<ul>
-  <li>Friendly</li>
-  <li>Informative</li>
-  <li>Helpful</li>
-  <li>Supportive</li>
-</ul>
+* Friendly
+* Informative
+* Helpful
+* Supportive
 
 ## In-app content hierarchy
 
-<div class="border border-base-light padding-3">
-  <!--alert-error-->
-  <div class="usa-alert usa-alert--error">
-    <div class="usa-alert__body">
-      <p class="usa-alert__text">Alert appear at the top, when applicable</p>
+<div class="maxw-tablet">
+  <div class="border border-base-light padding-5">
+    <!--alert-error-->
+    <div class="usa-alert usa-alert--error">
+      <div class="usa-alert__body">
+        <p class="usa-alert__text">Alert appear at the top, when applicable</p>
+      </div>
     </div>
+    <!--text-->
+    <h1 class="usa-prose">Call to action</h1>
+    <p>More information that explain what we're asking for and how it affects the user.</p>  
+    <p class="bg-gray-5 padding-5">Form fields / interaction space</p>
+    <button class="usa-button">Forward navigation</button>
+    <div class="border-top margin-top-4"></div>
+    <a href="#" class="primary">Cancel / close / back navigation</a>
   </div>
-  <!--text-->
-  <h1>Call to action</h1>
-
-  <p>More information that explain what we're asking for and how it affects the user.</p>
-  
-  <p class="bg-gray-5 padding-5">Form fields / interaction space</p>
-
-  <button class="usa-button">Forward navigation</button>
-  <div class="border-top margin-top-4"></div>
-  <a href="#" class="primary">Cancel / close / back navigation</a>
 </div>
 
 ## Common terms and phrases

--- a/docs/content.md
+++ b/docs/content.md
@@ -45,12 +45,18 @@ Login.gov’s voice is&hellip;
       </div>
     </div>
     <!--text-->
-    <h1 class="usa-prose">Call to action</h1>
-    <p>More information that explain what we're asking for and how it affects the user.</p>  
-    <p class="bg-gray-5 padding-5">Form fields / interaction space</p>
+    <div class="usa-prose margin-y-5">
+      <h1 class="">Call to action</h1>
+      <p>More information that explain what we're asking for and how it affects the user.</p>  
+    </div>
+    <div class="margin-y-6">
+      <p class="bg-gray-5 padding-5">Form fields / interaction space</p>
+    </div>
     <button class="usa-button">Forward navigation</button>
     <div class="border-top margin-top-4"></div>
-    <a href="#" class="primary">Cancel / close / back navigation</a>
+    <div class="usa-prose margin-top-2">
+      <a href="#" class="primary">Cancel / close / back navigation</a>
+    </div>
   </div>
 </div>
 

--- a/docs/content.md
+++ b/docs/content.md
@@ -1,0 +1,107 @@
+---
+permalink: /content/
+title: Content
+sidenav:
+  - text: Content principles
+    href: "#content-principles"
+  - text: Voice and Tone
+    href: "#voice-and-tone"
+  - text: In-app content hierarchy
+    href: "#in-app-content-hierarchy"
+  - text: Common terms and phrases
+    href: "#common-terms-and-phrases"
+  - text: Translations
+    href: "#translations"
+
+lead: >
+  This guide is intended to help login.gov team members create content that is consistent and accessible to our users.
+---
+
+We follow the 18F content guide and federal plain language guidelines. This guide is intended as a supplement to those guides.
+
+We follow the AP Stylebook for grammar. If you have a grammatical question that is not answered here, please use it as a reference.
+
+## Content principles
+
+Reference the [18F content principles](https://content-guide.18f.gov/content-principles/).
+
+## Voice and Tone
+
+Login.gov’s voice is&hellip;
+
+<ul>
+  <li>Friendly</li>
+  <li>Informative</li>
+  <li>Helpful</li>
+  <li>Supportive</li>
+</ul>
+
+## In-app content hierarchy
+
+<div class="border border-base-light padding-3">
+  <!--alert-error-->
+  <div class="usa-alert usa-alert--error">
+    <div class="usa-alert__body">
+      <p class="usa-alert__text">Alert appear at the top, when applicable</p>
+    </div>
+  </div>
+  <!--text-->
+  <h1>Call to action</h1>
+
+  <p>More information that explain what we're asking for and how it affects the user.</p>
+  
+  <p class="bg-gray-5 padding-5">Form fields / interaction space</p>
+
+  <button class="usa-button">Forward navigation</button>
+  <div class="border-top margin-top-4"></div>
+  <a href="#" class="primary">Cancel / close / back navigation</a>
+</div>
+
+## Common terms and phrases
+
+|Correct term or phrase   	|Common errors   	|More information   	|
+|---	|---	|---	|
+|login.gov   	|Login; Login.gov; LOGIN.gov; LOGIN   	|Use all lowercase and include the “.gov”. When at the beginning of a sentence, capitalize the first L.   	|
+|Online identity proofing, prove your identity   	|Identity verification, verify your identity,   	|   	|
+|two-factor authentication (2FA)   	|multi-factor authentication (MFA)   	|Always write out on first use   	|
+|authentication method   	|authentication device; secondary authentication devise; authentication factor; two-factor authenticator; security option; security method; security factor   	|   	|
+|sign in; sign in to   	|log in; sign into; log into   	|For better readability and visual differentiation from login.gov   	|
+|Must; have to   	|should   	|Do not use “should” when it is a required action   	|
+|can   	|may   	|“Can” add clarity   	|
+|Identity verification; verifying your identity   	|Proofing your identity, IAL2   	|IAL2 is only used internally and when communicating with partners who are looking for NIST standards. Never use IAL2 when communicating with users in the app. It’s acceptable to explain with “prove you are who you say you are”   	|
+|Users   	|Citizens, Americans   	|Use inclusive language when referring to our users   	|
+|email   	|e-mail   	|   	|
+|U.S.   	|US   	|   	|
+|AM or PM   	|am/pm, a.m./p.m., A.M./P.M., military time   	|   	|
+|Add   	|Enable   	|   	|
+|Delete   	|Disable, Remove   	|For permanent removal   	|
+|Login.gov account   	|Login.gov profile  	|Example: You sign in to your login.gov account to see your USAJOBS profile   	|
+|   	|Encrypt   	|Avoid using “encrypt” in the UI. If needed, do not use it as a call to action and use explanatory text   	|
+|Government application   	|SP   	|When referring to SPs in general terms. When, possible name the specific SP in the UI.   	|
+|Security code   	|one-time password (OTP)   	|The code users receive by phone or authentication app. OTP is for internal use only.   	|
+
+## Translations
+
+In addition to English, we translate content into French and Spanish. Write content that is straightforward, active voice, 
+
+**Resource:**
+
+* [Digital.gov’s Designing for Translation](https://digital.gov/2018/12/20/designing-for-translation/)
+* [Multilingual Community of Practice](https://digital.gov/communities/multilingual/)
+* [USAGov Bilingual Style Guide](https://www.usa.gov/style-guide/table-of-contents)
+
+If an English acronym is used, include the acronym, a comma and sigla en inglés (GSA, sigla en inglés).
+
+### Common translations
+
+|English   	|Spanish   	|French   	|
+|---	|---	|---	|
+|Authentication app   	|Aplicación de autenticación  	|Application d'authentification   	|
+|Authentication method   	|Método de autentificación   	|Méthode d'authentification   	|
+|Backup codes   	|Códigos de respaldo   	|Codes de sauvegarde   	|
+|Government applications    |Aplicaciones gubernamentales   |Applications gouvernementales   |
+|Government employee ID (PIV/CAC card)   	|Identificación de empleado del gobierno (tarjeta PIV/CAC)   	|Numéro d'employé du gouvernement (Carte PIV/CAC)   	|
+|Personal key   	|Llave personal   	|Clé personnelle   	|
+|Phone   	|Teléfono   	|Téléphone   	|
+|Security key   	|Llave de seguridad   	|Clé de sécurité   	|
+|Two-factor authentication   	|Autenticación de dos factores   	|Authentification à deux facteurs   	|

--- a/src/scss/components/_navbar.scss
+++ b/src/scss/components/_navbar.scss
@@ -75,6 +75,7 @@ $header-height: 10;
         font-weight: normal;
         color: color('primary');
         text-transform: uppercase;
+        @include u-margin-x(-0.5);
 
         &:hover {
           @include add-bar(0.5, 'secondary', 'bottom', 0, 2, 0);


### PR DESCRIPTION
This PR addresses the need for #123 

**Why:** By consistently practicing language in an intentional way, we can provide content that supports login.gov users’ needs and improve their experience on our sites and materials.

**How:**

-  Uses [Login.gov Content Guidelines](https://docs.google.com/document/d/1gasSrnvRG7BVB_iK8YUeXteBymhN0u1Ywz7EABNgJh0/edit#heading=h.r8bl0nbf9nug) 🔒as a reference to develop the page
- Adds _Content_ as its own navbar link item to make space for additional tips/guide in the future
- Reduces margin-left/right spacing in navbar to reduce crowding (Related: #126)

**Seeking feedback:**

- If it's easy to scan through the page
- If the order of content is clear
- If there is any typo to correct

## Proposed page - See screenshot below

![Screenshot_2020-01-13 Content login gov Design System](https://user-images.githubusercontent.com/6327082/72277896-6f148a00-35f8-11ea-8cf9-b73c43c6459a.png)
 