### PR TITLE
Patch _code.scss rendering 

### DIFF
--- a/src/scss/components/_code.scss
+++ b/src/scss/components/_code.scss
@@ -44,7 +44,7 @@ pre {
     z-index: 1;
     top: $block-border-width;
     bottom: $block-border-width;
-    width: $block-padding-width;
+    width: 0;
     border-radius: $block-border-radius;
   }
 


### PR DESCRIPTION
**Why:** To patch a rendering issue identified in [identity-dev-docs' PR #102](https://github.com/18F/identity-dev-docs/pull/102)

**How:** Redefine both `.highlight::before` and `.highlight::after` width from `$block-border-width` to `0`

When reviewed and merged, we will publish a `patch` release to npm

## Before (left column) / after (right column) rendering for Chrome, Firefox and Safari

<img width="1039" alt="code-highlight-rendering" src="https://user-images.githubusercontent.com/6327082/74553316-b904ce80-4f1c-11ea-8319-cdad9cb05ee2.png">

