### PR TITLE
Documentation: Update package.json to correct the landing page info

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "identity-style-guide",
-  "version": "2.1.6",
+  "version": "2.2.1",
   "description": "The global style of login.gov",
   "scripts": {
     "start": "make start",


### PR DESCRIPTION
**Why:** On the [design.login.gov](https://design.login.gov/) landing page, the `2.1.6` release number doesn't accurately reflect the [latest npm package release](https://www.npmjs.com/package/identity-style-guide), which is `2.2.1`, potentially confusing team members. 

**How:** 
- Updated the package.json file

## Before
![ds-before-2 1 6](https://user-images.githubusercontent.com/6327082/75292125-349e2f80-57e9-11ea-939f-07ecbeb3f623.png)

## Proposed 
![ds-before-2 2 1](https://user-images.githubusercontent.com/6327082/75292137-39fb7a00-57e9-11ea-8506-6669e3199b6d.png)

