### PR TITLE
LG-2788 add rules for form "link-buttons"

### DIFF
--- a/src/scss/components/_buttons.scss
+++ b/src/scss/components/_buttons.scss
@@ -206,7 +206,7 @@
   padding: units(1) units(1);
 }
 
-.usa-form a.usa-button.usa-button--danger {
+.usa-form a.usa-button.usa-button--danger { /* stylelint-disable-line selector-no-qualifying-type */
   color: color('white');
   text-decoration: none;
 
@@ -216,7 +216,7 @@
   }
 }
 
-.usa-form a.usa-button.usa-button--outline {
+.usa-form a.usa-button.usa-button--outline { /* stylelint-disable-line selector-no-qualifying-type */
   color: color('primary');
   text-decoration: none;
 

--- a/src/scss/components/_buttons.scss
+++ b/src/scss/components/_buttons.scss
@@ -205,3 +205,23 @@
   font-size: font-size($theme-button-font-family, 'micro');
   padding: units(1) units(1);
 }
+
+.usa-form a.usa-button.usa-button--danger {
+  color: color('white');
+  text-decoration: none;
+
+  &:visited {
+    color: color('white');
+    text-decoration: none;
+  }
+}
+
+.usa-form a.usa-button.usa-button--outline {
+  color: color('primary');
+  text-decoration: none;
+
+  &:visited {
+    color: color('primary');
+    text-decoration: none;
+  }
+}


### PR DESCRIPTION
**Why:** The design system has CSS rules for links in forms that override the button styling when we place a button class on links within a form. We need to be able to style links as buttons in forms where we have not only a "Submit" button, but "Delete" and "Cancel" buttons which would fight over being the One True Form Button if we did not make them links.