### PR TITLE
Update`#login-design` Slack channel to `#login-ux`

### DIFF
--- a/docs/brand.md
+++ b/docs/brand.md
@@ -125,4 +125,4 @@ Illustration is most effective when it is precise in choosing a single message t
 
 ## Slide decks
 
-If you're looking to build a new slide deck, please use the official Login.gov slide template [available on Google Drive](https://docs.google.com/presentation/d/1UYyKTTaFmttIm46wxeupGgfozCix-RHLCvTiRZot6Mc/edit). Users of the slide deck template can submit additional template suggestions to the #login-design slack channel.
+If you're looking to build a new slide deck, please use the official Login.gov slide template [available on Google Drive](https://docs.google.com/presentation/d/1UYyKTTaFmttIm46wxeupGgfozCix-RHLCvTiRZot6Mc/edit). Users of the slide deck template can submit additional template suggestions to the #login-ux slack channel.


### PR DESCRIPTION
**Why:** In the slide deck section, the `#login-design` reference should be updated to `#login-ux` to reflect the latest name (and in my not humble opinion, the best channel in all of TTS Slack)