### PR TITLE
Define main entrypoint for use as Node package

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "identity-style-guide",
   "version": "2.2.3",
   "description": "The global style of login.gov",
+  "main": "dist/assets/js/main.js",
   "scripts": {
     "start": "make start",
     "clean": "make clean",


### PR DESCRIPTION
**Why**: To be able to import identity-style-guide from another script, it must define a main entrypoint.

Before|After
---|---
`import 'identity-style-guide/dist/assets/js/main';`|`import 'identity-style-guide';`

Example: https://github.com/18F/identity-idp/pull/3957

Reference: https://docs.npmjs.com/files/package.json#main

Compare upstream: https://github.com/uswds/uswds/blob/f7acaf7e09840f4f84b1398c4d30a977cd7fc1e5/package.json#L8

See resolution failure example: https://unpkg.com/identity-style-guide