### PR TITLE
Update Spinner documentation to recommend appropriate pixel density

### DIFF
--- a/docs/_components/spinner.md
+++ b/docs/_components/spinner.md
@@ -13,7 +13,7 @@ Spinners can be helpful to signal to a user that the current process may require
 {% capture example %}
 <div class="lg-spinner">
   <div>
-    <img src="{{ site.baseurl }}/assets/img/spinner.gif" srcset="{{ site.baseurl }}/assets/img/spinner@2x.gif" width="144" height="144" class="text-middle" alt="Spinner" />
+    <img src="{{ site.baseurl }}/assets/img/spinner.gif" srcset="{{ site.baseurl }}/assets/img/spinner.gif, {{ site.baseurl }}/assets/img/spinner@2x.gif 2x" width="144" height="144" class="text-middle" alt="Spinner" />
   </div>
 </div>
 {% endcapture %}
@@ -27,7 +27,7 @@ We may want to start with a hidden spinner and then remove it with a button clic
 <button class="usa-button__lg-invokeSpinner">Hide Button and trigger a spinner</button>
 <div class="lg-spinner lg-spinner--hidden" id="spinner-id">
   <div>
-    <img src="{{ site.baseurl }}/assets/img/spinner.gif" srcset="{{ site.baseurl }}/assets/img/spinner@2x.gif" width="144" height="144" class="text-middle" alt="Spinner" />
+    <img src="{{ site.baseurl }}/assets/img/spinner.gif" srcset="{{ site.baseurl }}/assets/img/spinner.gif, {{ site.baseurl }}/assets/img/spinner@2x.gif 2x" width="144" height="144" class="text-middle" alt="Spinner" />
   </div>
 </div>
 {% endcapture %}

--- a/docs/_components/spinner.md
+++ b/docs/_components/spinner.md
@@ -13,7 +13,15 @@ Spinners can be helpful to signal to a user that the current process may require
 {% capture example %}
 <div class="lg-spinner">
   <div>
-    <img src="{{ site.baseurl }}/assets/img/spinner.gif" srcset="{{ site.baseurl }}/assets/img/spinner.gif, {{ site.baseurl }}/assets/img/spinner@2x.gif 2x" width="144" height="144" class="text-middle" alt="Spinner" />
+    <img
+      src="{{ site.baseurl }}/assets/img/spinner.gif"
+      srcset="{{ site.baseurl }}/assets/img/spinner.gif,
+              {{ site.baseurl }}/assets/img/spinner@2x.gif 2x"
+      width="144"
+      height="144"
+      class="text-middle"
+      alt="Spinner"
+    />
   </div>
 </div>
 {% endcapture %}
@@ -27,7 +35,15 @@ We may want to start with a hidden spinner and then remove it with a button clic
 <button class="usa-button__lg-invokeSpinner">Hide Button and trigger a spinner</button>
 <div class="lg-spinner lg-spinner--hidden" id="spinner-id">
   <div>
-    <img src="{{ site.baseurl }}/assets/img/spinner.gif" srcset="{{ site.baseurl }}/assets/img/spinner.gif, {{ site.baseurl }}/assets/img/spinner@2x.gif 2x" width="144" height="144" class="text-middle" alt="Spinner" />
+    <img
+      src="{{ site.baseurl }}/assets/img/spinner.gif"
+      srcset="{{ site.baseurl }}/assets/img/spinner.gif,
+              {{ site.baseurl }}/assets/img/spinner@2x.gif 2x"
+      width="144"
+      height="144"
+      class="text-middle"
+      alt="Spinner"
+    />
   </div>
 </div>
 {% endcapture %}


### PR DESCRIPTION
**Why**: Browsers which support srcset can choose amongst given options the most appropriate, including for multiple pixel densities. Since `@2x` is tailored to 2x pixel density, it should ideally only be rendered when the display device has >1 pixel density. Currently, any browser which supports srcset will always show 2x, even if their display is not 2x.

Reference: https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images#Resolution_switching_Same_size_different_resolutions

Preview URL: https://federalist-2f194a10-945e-4413-be01-46ca6dae5358.app.cloud.gov/preview/18f/identity-style-guide/aduth-spinner-pixel-density/components/spinner/

**Screenshots:**

`1x` display|`2x` display
---|---
![1x display](https://user-images.githubusercontent.com/1779930/91081344-f9a07b80-e614-11ea-8cf1-ec1948979630.png)|<img width="859" alt="2x display" src="https://user-images.githubusercontent.com/1779930/91081338-f7d6b800-e614-11ea-97f5-95ba5a1d7eb0.png">
