### PR TITLE
Replace usa-input--error-message with usa-error-message (LG-3288, LG-3277)

### DIFF
--- a/docs/_components/form-fields.md
+++ b/docs/_components/form-fields.md
@@ -373,7 +373,7 @@ For radio buttons and checkboxes, simply add an error message directly after the
     </li>
   </ul>
 </fieldset>
-<span class="usa-error-message usa-input--error-message-with-icon" role="alert">Error message text.</span>
+<span class="usa-error-message usa-error-message--with-icon" role="alert">Error message text.</span>
 {% endcapture %}
 {% include helpers/code-example.html code=example %}
     </div>
@@ -405,7 +405,7 @@ For radio buttons and checkboxes, simply add an error message directly after the
     </li>
   </ul>
 </fieldset>
-<span class="usa-error-message usa-input--error-message-with-icon" role="alert">Error message text.</span>
+<span class="usa-error-message usa-error-message--with-icon" role="alert">Error message text.</span>
 {% endcapture %}
 {% include helpers/code-example.html code=example %}
     </div>
@@ -447,7 +447,7 @@ For radio buttons and checkboxes, simply add an error message directly after the
     </li>
   </ul>
 </fieldset>
-<span class="usa-error-message usa-input--error-message-with-icon" role="alert">Error message text.</span>
+<span class="usa-error-message usa-error-message--with-icon" role="alert">Error message text.</span>
 {% endcapture %}
 {% include helpers/code-example.html code=example %}
     </div>
@@ -479,7 +479,7 @@ For radio buttons and checkboxes, simply add an error message directly after the
     </li>
   </ul>
 </fieldset>
-<span class="usa-error-message usa-input--error-message-with-icon" role="alert">Error message text.</span>
+<span class="usa-error-message usa-error-message--with-icon" role="alert">Error message text.</span>
 {% endcapture %}
 {% include helpers/code-example.html code=example %}
     </div>
@@ -511,7 +511,7 @@ For radio buttons and checkboxes, simply add an error message directly after the
     </li>
   </ul>
 </fieldset>
-<span class="usa-error-message usa-input--error-message-with-icon" role="alert">Error message text.</span>
+<span class="usa-error-message usa-error-message--with-icon" role="alert">Error message text.</span>
 {% endcapture %}
 {% include helpers/code-example.html code=example %}
     </div>
@@ -553,7 +553,7 @@ For radio buttons and checkboxes, simply add an error message directly after the
     </li>
   </ul>
 </fieldset>
-<span class="usa-error-message usa-input--error-message-with-icon" role="alert">Error message text.</span>
+<span class="usa-error-message usa-error-message--with-icon" role="alert">Error message text.</span>
 {% endcapture %}
 {% include helpers/code-example.html code=example %}
     </div>

--- a/docs/_components/form-fields.md
+++ b/docs/_components/form-fields.md
@@ -259,8 +259,8 @@ a grid row.
 {% capture example %}
 
 <label for="e9a4" class="usa-label">Text input validation example</label>
-<input id="e9a4" type="text" class="usa-input usa-input-error">
-<span class="usa-input-error-message" role="alert">Error message text.</span>
+<input id="e9a4" type="text" class="usa-input usa-input--error">
+<span class="usa-error-message" role="alert">Error message text.</span>
 
 {% endcapture %}
 {% include helpers/code-example.html code=example %}
@@ -280,7 +280,7 @@ Follow the same pattern of applying `.usa-input--error` to the effected input an
 {% capture example %}
 <label for="a37c" class="usa-label">Textarea (multiline) input</label>
 <textarea id="a37c" type="text" class="usa-textarea usa-input--error"></textarea>
-<span class="usa-input--error-message" role="alert">Error message text.</span>
+<span class="usa-error-message" role="alert">Error message text.</span>
 {% endcapture %}
 {% include helpers/code-example.html code=example %}
     </div>
@@ -312,7 +312,7 @@ Follow the same pattern of applying `.usa-input--error` to the effected input an
     </div>
   </div>
   <span class="usa-form-hint" id="f9e5">Example: 04 28 1986</span>
-  <span class="usa-input--error-message" role="alert">Error message text.</span>
+  <span class="usa-error-message" role="alert">Error message text.</span>
 </fieldset>
 {% endcapture %}
 {% include helpers/code-example.html code=example %}
@@ -335,7 +335,7 @@ Follow the same pattern of applying `.usa-input--error` to the effected input an
   <option value="value2">Option B</option>
   <option value="value3">Option C</option>
 </select>
-<span class="usa-input--error-message" role="alert">Error message text.</span>
+<span class="usa-error-message" role="alert">Error message text.</span>
 {% endcapture %}
 {% include helpers/code-example.html code=example %}
     </div>
@@ -373,7 +373,7 @@ For radio buttons and checkboxes, simply add an error message directly after the
     </li>
   </ul>
 </fieldset>
-<span class="usa-input--error-message usa-input--error-message-with-icon" role="alert">Error message text.</span>
+<span class="usa-error-message usa-input--error-message-with-icon" role="alert">Error message text.</span>
 {% endcapture %}
 {% include helpers/code-example.html code=example %}
     </div>
@@ -405,7 +405,7 @@ For radio buttons and checkboxes, simply add an error message directly after the
     </li>
   </ul>
 </fieldset>
-<span class="usa-input--error-message usa-input--error-message-with-icon" role="alert">Error message text.</span>
+<span class="usa-error-message usa-input--error-message-with-icon" role="alert">Error message text.</span>
 {% endcapture %}
 {% include helpers/code-example.html code=example %}
     </div>
@@ -447,7 +447,7 @@ For radio buttons and checkboxes, simply add an error message directly after the
     </li>
   </ul>
 </fieldset>
-<span class="usa-input--error-message usa-input--error-message-with-icon" role="alert">Error message text.</span>
+<span class="usa-error-message usa-input--error-message-with-icon" role="alert">Error message text.</span>
 {% endcapture %}
 {% include helpers/code-example.html code=example %}
     </div>
@@ -479,7 +479,7 @@ For radio buttons and checkboxes, simply add an error message directly after the
     </li>
   </ul>
 </fieldset>
-<span class="usa-input--error-message usa-input--error-message-with-icon" role="alert">Error message text.</span>
+<span class="usa-error-message usa-input--error-message-with-icon" role="alert">Error message text.</span>
 {% endcapture %}
 {% include helpers/code-example.html code=example %}
     </div>
@@ -511,7 +511,7 @@ For radio buttons and checkboxes, simply add an error message directly after the
     </li>
   </ul>
 </fieldset>
-<span class="usa-input--error-message usa-input--error-message-with-icon" role="alert">Error message text.</span>
+<span class="usa-error-message usa-input--error-message-with-icon" role="alert">Error message text.</span>
 {% endcapture %}
 {% include helpers/code-example.html code=example %}
     </div>
@@ -553,7 +553,7 @@ For radio buttons and checkboxes, simply add an error message directly after the
     </li>
   </ul>
 </fieldset>
-<span class="usa-input--error-message usa-input--error-message-with-icon" role="alert">Error message text.</span>
+<span class="usa-error-message usa-input--error-message-with-icon" role="alert">Error message text.</span>
 {% endcapture %}
 {% include helpers/code-example.html code=example %}
     </div>

--- a/src/scss/components/_inputs.scss
+++ b/src/scss/components/_inputs.scss
@@ -193,7 +193,7 @@ $border-width: 1px;
 .usa-error-message {
   color: color('error');
 
-  &.usa-input--error-message-with-icon {
+  &.usa-error-message--with-icon {
     @include add-background-svg('alerts/error');
     background-position: 0 center;
     background-size: units($icon-size);

--- a/src/scss/components/_inputs.scss
+++ b/src/scss/components/_inputs.scss
@@ -190,7 +190,7 @@ $border-width: 1px;
   display: inline-block;
 }
 
-.usa-input--error-message {
+.usa-error-message {
   color: color('error');
 
   &.usa-input--error-message-with-icon {


### PR DESCRIPTION
**Why**: For improved alignment with USWDS, to reduce the likelihood of inconsistent error styling.

Relevant USWDS documentation: https://designsystem.digital.gov/components/form-controls/#text-input

Toward LG-3288, this backports the following revisions from IDP:

https://github.com/18F/identity-idp/blob/73c3c13/app/assets/stylesheets/components/_typography.scss#L51-L57

**Open questions:**

- USWDS includes more styling for error messages than what had existed previously with `usa-input--error-message` ([padding, display, font weight](https://github.com/uswds/uswds/blob/22a9eb278196340c3c8909ff5dbeef4ff39756fd/src/stylesheets/elements/form-controls/_global.scss#L54-L59)). Are all of those stylings agreeable, or should we revert back to the original styling? For example, overriding font weight back to `normal`.
- As noted in the associated tickets, USWDS uses the `error-dark` color token for error messages. Based on how errors are styled throughout the IDP, I've opted to keep this as the existing `error` color token in the styling overrides.
- The Login Design System also includes an error message variant including an icon, styled using the `usa-input--error-message-with-icon` class. This pull request does not currently propose any changes to this class, though in considering this as a [BEM modifier](http://getbem.com/naming/) of the error message class, it may be appropriate to update this accordingly to `usa-error-message--with-icon`.

**Screenshots:**

Before|After
---|---
![before](https://user-images.githubusercontent.com/1779930/94457137-2a2e8480-0182-11eb-8d02-28452e51c0f5.png)|![after](https://user-images.githubusercontent.com/1779930/94457067-171bb480-0182-11eb-92a4-3285ff659d41.png)

