### PR TITLE
Toggle hidden content visible for visual regression tests

### DIFF
--- a/test/screenshot.test.js
+++ b/test/screenshot.test.js
@@ -38,9 +38,18 @@ async function stubAnimations() {
   });
 }
 
+async function toggleHiddenContent() {
+  await page.$$eval('.usa-accordion__container', (containers) => (
+    containers.forEach((container) => container.removeAttribute('hidden'))
+  ));
+}
+
 async function getScreenshot(url) {
   await page.goto(url);
-  await stubAnimations();
+  await Promise.all([
+    stubAnimations(),
+    toggleHiddenContent(),
+  ]);
   return page.screenshot({ fullPage: true });
 }
 

--- a/test/screenshot.test.js
+++ b/test/screenshot.test.js
@@ -39,17 +39,14 @@ async function stubAnimations() {
 }
 
 async function toggleHiddenContent() {
-  await page.$$eval('.usa-accordion__container', (containers) => (
-    containers.forEach((container) => container.removeAttribute('hidden'))
-  ));
+  await page.$$eval('.usa-accordion__container', (containers) =>
+    containers.forEach((container) => container.removeAttribute('hidden')),
+  );
 }
 
 async function getScreenshot(url) {
   await page.goto(url);
-  await Promise.all([
-    stubAnimations(),
-    toggleHiddenContent(),
-  ]);
+  await Promise.all([stubAnimations(), toggleHiddenContent()]);
   return page.screenshot({ fullPage: true });
 }
 


### PR DESCRIPTION
**Why**: Check for regressions of content which may be collapsed (hidden) by default.