### PR TITLE
Only check diffs of lockfiles in lint task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ validate-gemfile-lock: Gemfile Gemfile.lock
 
 validate-package-lock: package.json package-lock.json
 	@echo "Validating package-lock.json..."
-	@npm install
+	@npm install --ignore-scripts
 	@git diff-index --quiet HEAD package-lock.json || (echo "Error: There are uncommitted changes after running 'npm install'"; exit 1)
 
 validate-lockfiles: validate-gemfile-lock validate-package-lock

--- a/Makefile
+++ b/Makefile
@@ -24,12 +24,12 @@ start-assets: build-fonts build-images
 validate-gemfile-lock: Gemfile Gemfile.lock
 	@echo "Validating Gemfile.lock..."
 	@bundle check
-	@git diff-index --quiet HEAD || (echo "Error: There are uncommitted changes after running 'bundle install'"; exit 1)
+	@git diff-index --quiet HEAD Gemfile.lock || (echo "Error: There are uncommitted changes after running 'bundle install'"; exit 1)
 
 validate-package-lock: package.json package-lock.json
 	@echo "Validating package-lock.json..."
 	@npm install
-	@git diff-index --quiet HEAD || (echo "Error: There are uncommitted changes after running 'npm install'"; exit 1)
+	@git diff-index --quiet HEAD package-lock.json || (echo "Error: There are uncommitted changes after running 'npm install'"; exit 1)
 
 validate-lockfiles: validate-gemfile-lock validate-package-lock
 


### PR DESCRIPTION
Couple small improvements to lockfile validation implemented in #161:

- 2e48906 Only check diffs of lockfiles in lint task
  - **Why**: It may be common to run `npm run lint` before committing changes unrelated to lockfiles, which should not fail due to the fact that there are uncommitted changes.
- fe1c664 Ignore scripts in package-lock.json validation npm install
  - **Why**: Faster. Especially since this project runs `bundle install` as a postinstall script, which in lockfile validation is redundant with validate-gemfile-lock. Still satisfies purpose of lockfile validation