### PR TITLE
Fix basic styles setting assignment

### DIFF
--- a/src/scss/uswds-theme/_typography.scss
+++ b/src/scss/uswds-theme/_typography.scss
@@ -53,16 +53,20 @@ $theme-root-font-size: 16px;
 
 /*
 ----------------------------------------
-Basic styles
+Global styles
 ----------------------------------------
-Sets the default typography styles for
-paragraph text and links
-
-Accepts true or false
+Adds basic styling for the following
+unclassed elements:
+- paragraph: paragraph text
+- link: links
+- content: paragraph text, links,
+  headings, lists, and tables
 ----------------------------------------
 */
 
-$theme-global-styles-basic: true;
+$theme-global-paragraph-styles: true;
+$theme-global-link-styles: true;
+$theme-global-content-styles: true;
 
 /*
 ----------------------------------------

--- a/src/scss/uswds-theme/_typography.scss
+++ b/src/scss/uswds-theme/_typography.scss
@@ -64,9 +64,9 @@ unclassed elements:
 ----------------------------------------
 */
 
-$theme-global-paragraph-styles: true;
-$theme-global-link-styles: true;
-$theme-global-content-styles: true;
+$theme-global-paragraph-styles: false;
+$theme-global-link-styles: false;
+$theme-global-content-styles: false;
 
 /*
 ----------------------------------------


### PR DESCRIPTION
**Why**: The design system assigns `$theme-global-styles-basic: true;` with the intention of assigning basic styles for common base elements, but this does not apply, because the `$theme-global-styles-basic` setting does not exist. It was replaced with three separate variables as part of the USWDS 2.0.0 beta release process:

>- Replaced the `$theme-global-styles-basic` variable with three explicit global styling vars — each set to `false` by default.
>   - `$theme-global-paragraph-styles` applies styling to `p` elements
>   - `$theme-global-link-styles` applies styling to `a` elements
>   - `$theme-global-content-styles` applies styling to `p`, `a`, `h[1-6]`, `ol`, `ul`, and `table` elements

https://designsystem.digital.gov/about/releases/#version-200-beta-6

~This is not quite ready for review, because it causes regressions discovered in visual regression tests (which, as an aside, serves conveniently for demonstration of visual regression tests).~

**Edit:** See comments below. As discussed, the intention is to keep the global styles as not applied by default.