### PR TITLE
Implement dropdown button as component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 2.2.4
+
+### Bug Fixes
+
+- Fixed support for multiple dropdown buttons on a page.

--- a/src/js/components/dropdownButton.js
+++ b/src/js/components/dropdownButton.js
@@ -1,34 +1,19 @@
-document.addEventListener('DOMContentLoaded', () => {
-  const mobileLink = document.querySelector('.dropdown-mobile-toggle > button');
-  const mobileDropdown = document.querySelector('.mobile-dropdown');
-  const desktopLink = document.querySelector('.dropdown-desktop-toggle > button');
-  const desktopDropdown = document.querySelector('.desktop-dropdown');
+const behavior = require('uswds/src/js/utils/behavior');
 
-  function addListenerMulti(el, s, fn) {
-    s.split(' ').forEach((e) => el.addEventListener(e, fn, false));
-  }
+function createDropdownPicker(contentSelector) {
+  return function onDropdownButtonClickOrKeyPress(event) {
+    const button = event.target;
+    const content = button.parentNode.querySelector(contentSelector);
+    const isExpanded = !content.classList.toggle('display-none');
+    button.setAttribute('aria-expanded', isExpanded.toString());
+  };
+}
 
-  function toggleAriaExpanded(element) {
-    if (element.getAttribute('aria-expanded') === 'true') {
-      element.setAttribute('aria-expanded', 'false');
-    } else {
-      element.setAttribute('aria-expanded', 'true');
-    }
-  }
-
-  function dropdownPicker(trigger, dropdown) {
-    addListenerMulti(trigger, 'click keypress', function (event) {
-      const eventType = event.type;
-
-      event.preventDefault();
-      if (eventType === 'click' || (eventType === 'keypress' && event.which === 13)) {
-        this.parentNode.classList.toggle('focused');
-        dropdown.classList.toggle('display-none');
-        toggleAriaExpanded(this);
-      }
-    });
-  }
-
-  if (desktopLink) dropdownPicker(desktopLink, desktopDropdown);
-  if (mobileLink) dropdownPicker(mobileLink, mobileDropdown);
+const dropdownButton = behavior({
+  click: {
+    '.dropdown-mobile-toggle > button': createDropdownPicker('.mobile-dropdown'),
+    '.dropdown-desktop-toggle > button': createDropdownPicker('.desktop-dropdown'),
+  },
 });
+
+module.exports = dropdownButton;

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -14,6 +14,7 @@ const components = require('uswds/src/js/components');
 components.accordionCloseButton = require('./components/accordionCloseButton');
 components.inputPasswordMeter = require('./components/inputPasswordStrength');
 components.invokeSpinner = require('./components/invokeSpinner');
+components.dropdownButton = require('./components/dropdownButton');
 
 uswds.components = components;
 
@@ -25,7 +26,5 @@ domready(() => {
       behavior.on(target);
     });
 });
-
-require('./components/dropdownButton');
 
 module.exports = uswds;


### PR DESCRIPTION
Related: #165

The [dropdown button](https://design.login.gov/components/buttons/#dropdown) JavaScript implementation was not previously implemented as a USWDS-conventional component. Because it contained side-effects to initialize a dropdown button on a page, it was excluded from the package in #165, and only available in the `main.js` precompiled JavaScript bundle. This pull request refactors the code to bring it in line with other components.

Incidentally, this also resolves an issue where only one dropdown button could exist on a page.

**Future Work:**

- Button should assign `aria-controls` to complement existing `aria-expanded` ([documentation](https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-expanded)).
   - >If the element with the `aria-expanded` attribute controls the expansion of another grouping container that is not 'owned by' the element, the author **SHOULD** reference the container by using the `aria-controls` attribute.
- Consider deprecating, or at least finding a way to maximize reuse of similar accordion behaviors, which already handle most of `aria-expanded` and `aria-controls` behavior.
- Consolidate to eliminate separation between mobile and desktop markup (impacted dashboard only appears to use desktop markup anyways)
   - In the process, consider renaming classes to follow standard conventions (`usa-` or `lg-` prefixed)

**Impact:**

The button only appears to be used in the dashboard, in a view which may in-fact not be used? ([source](https://github.com/18F/identity-dashboard/blob/master/app/views/manage_users/_add_user_options_dropdown.html.erb))