### PR TITLE
Prepare 3.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,28 +58,18 @@ More information can be found in Federalist’s [How Builds Work](https://federa
 
 When you're ready to release a new version of the `identity-style-guide` package there are just a few steps to take.
 
-1️⃣ Make sure all the changes indended for release are merged into the `master` branch.
-
-2️⃣ Check out the master branch on your local machine by running `git checkout master`
-
-3️⃣ Decide on a version. The login.gov design system uses [semantic versioning](https://semver.org/). Once you decide whether you're going to release a `patch`, `minor`, or `major` version, run the appropriate `npm` command like
-
-`npm version patch -m "Upgrade to %s for reasons"`
-
-And a new version will be created.
-
-4️⃣ Once you’re satisfied with any updates, do a trial publish to `npm` by running:
-
-```
-npm publish --dry-run
-```
-
-No need to run any special build steps — the publish script will lint the source JavaScript and Sass files, and clean and re-build all assets before including them in the published package.
-
-5️⃣ If everything looks alright, continue with publishing:
-
-```
-npm publish
-```
-
-6️⃣ Document the release on Github. After you've pushed the release changes back up to `master`, [create a new release](https://github.com/18F/identity-style-guide/releases) with a target of `master`. The release version should match the version you just sent off to `npm` (like `v2.1.5`) and the title can be the same. Use the release notes to link to any important issues or pull requests that were addressed in the release.
+1. Make sure all the changes intended for release are merged into the `master` branch.
+2. Check out the master branch on your local machine by running `git checkout master`.
+3. Run `npm version` to bump the package version, passing one of `patch`, `minor`, or `major` depending on the types of changes included.
+   - Example: `npm version patch`
+   - This project uses [semantic versioning](https://semver.org/): breaking changes should bump the major version, backwards-compatible changes should bump the minor version, and bug fixes should bump the patch version.
+   - Ideally all changes to be included in this version have been described in `CHANGELOG.md` to make the choice of version obvious.
+4. A new version will be created. This will update `package.json` and `package-lock.json` automatically and create a commit that should be pushed.
+5. Do a trial publish by running `npm publish --dry-run`.
+   - No need to run any special build steps — the publish script will lint the source JavaScript and Sass files, and clean and re-build all assets before including them in the published package.
+6. If everything looks alright, continue with publishing by running `npm publish`.
+7. Create a new release on the [GitHub "Releases" page](https://github.com/18F/identity-style-guide/releases).
+   - Use `master` as the target.
+   - The release version should match the version just published to `npm` (for example, `v2.1.5`).
+   - Use the version name as the release title.
+   - Use the release notes to link to any important issues or pull requests that were addressed in the release. You may copy this from `CHANGELOG.md`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "identity-style-guide",
-  "version": "2.2.3",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "identity-style-guide",
-  "version": "2.2.3",
+  "version": "3.0.0",
   "description": "The global style of login.gov",
   "main": "./build/cjs/index.js",
   "module": "./build/esm/index.js",


### PR DESCRIPTION
Bumps version in `package.json` and `package-lock.json`.

I assume it'd not always be necessary to create a pull request like this for a release, though a few points of the documented release process were not entirely clear to me, or should be updated to account for the introduction of a `CHANGELOG.md`.

There's an open question as to whether we would want a `CHANGELOG.md` at all, or at least if one or the other of a release notes and `CHANGELOG.md` should be eliminated, since as proposed, they're duplicated and could fall out of sync. The argument for a dedicated changelog file is (a) to simplify role of release manager in understanding the changes for consideration of the SemVer version if separate from the contributors, (b) accountability that all changes are logged by encouraging changelog notes to accompany any pull request, and (c) for package consumers to have transparency to upcoming unreleased changes.

See extended commit message for rationale of README revisions:

>**Why**: Account for CHANGELOG.md, describe missing steps (e.g. committing version bump), accessible Markdown markup (WCAG 2.0 H48: "Using ol, ul and dl for lists or groups of links"), fix typos ("indended" -> "intended", "Github" -> "GitHub")