### PR TITLE
Use ESM import/export syntax for dropdown button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix an issue where builds may produce styles in an unpredictable order.
 - Fix an issue where `.usa-display` heading font size was rendered larger than intended.
+- Fix an issue where `dropdownButton` was using invalid CommonJS syntax when imported from ES module entrypoint.
 
 ### Internal
 

--- a/src/js/components/dropdownButton.js
+++ b/src/js/components/dropdownButton.js
@@ -1,4 +1,4 @@
-const behavior = require('uswds/src/js/utils/behavior');
+import behavior from 'uswds/src/js/utils/behavior';
 
 function createDropdownPicker(contentSelector) {
   return function onDropdownButtonClickOrKeyPress(event) {
@@ -16,4 +16,4 @@ const dropdownButton = behavior({
   },
 });
 
-module.exports = dropdownButton;
+export default dropdownButton;


### PR DESCRIPTION
**Why**: When using the ES module entrypoint, CommonJS "module.exports" and "require" are invalid.

This should only be an issue when using the ES module entrypoint `build/esm/index.js`, and not an issue for CommonJS usage (`build/cjs/index.js`) or the precompiled copy (`dist/assets/js/main.js`).

This was likely missed due to merge timing between #166 and #165.