### PR TITLE
Remove slide deck reference from design.login.gov.

### DIFF
--- a/docs/brand.md
+++ b/docs/brand.md
@@ -10,8 +10,6 @@ sidenav:
     href: "#tagline"
   - text: Illustration
     href: "#illustration"
-  - text: Slide decks
-    href: "#slide-decks"
 lead: >
   When working with the login.gov brand, follow these guidelines to ensure you're representing the product in a consistent way across all mediums.
 ---

--- a/docs/brand.md
+++ b/docs/brand.md
@@ -132,7 +132,3 @@ Illustration is most effective when it is precise in choosing a single message t
   <img src="{{ site.baseurl }}/assets/img/illustrations/fail.svg" role="img" alt="Failure illustration" class="display-block grid-col flex-auto flex-align-center">
   <img src="{{ site.baseurl }}/assets/img/illustrations/id-confirm.svg" role="img" alt="Confirmed identification illustration" class="display-block grid-col flex-auto flex-align-center">
 </div>
-
-## Slide decks
-
-If you're looking to build a new slide deck, please use the official Login.gov slide template [available on Google Drive](https://docs.google.com/presentation/d/1UYyKTTaFmttIm46wxeupGgfozCix-RHLCvTiRZot6Mc/edit). Users of the slide deck template can submit additional template suggestions to the #login-ux slack channel.


### PR DESCRIPTION
Removing the reference to an outdated slide deck from design.login.gov - new year, new deck! 🌮 