### PR TITLE
Enable Jekyll redirect plugin

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,7 @@ keep_files:
 
 plugins:
   - jekyll-sitemap
+  - jekyll-redirect-from
 
 collections:
   components:


### PR DESCRIPTION
**Why**: So that accessibility redirect introduced in #178 does redirect.