### PR TITLE
Link to base USWDS component documentation

### DIFF
--- a/docs/_components/accordions.md
+++ b/docs/_components/accordions.md
@@ -4,6 +4,8 @@ lead: >
   Accordions are a list of headers that can be clicked to hide or reveal additional content.
 ---
 
+{% include helpers/base-component.html component="accordion" stylesheet="accordions" %}
+
 Before using an accordion, consider if their use would hinder usability. If there is not enough content to warrant condensing or if visitors need to see most or all of the information on a page, use well-formatted text instead.
 
 {% capture example %}

--- a/docs/_components/alerts.md
+++ b/docs/_components/alerts.md
@@ -9,10 +9,12 @@ subnav:
     href: "#limiting-alert-width"
 ---
 
+{% include helpers/base-component.html component="alert" stylesheet="alerts" %}
+
 ## Alert Usage
 
 In the application user interface, alerts should be used whenever a user initiates an action and returns to the same place once the action is complete or fails.
-  
+
 If the action is part of a flow, meaning the user will advance to another step or fail out, a separate screen or view should be used to indicate success of failure.
 
 Visit the [USWDS Alerts component](https://designsystem.digital.gov/components/alert/) page for more information and usage examples

--- a/docs/_components/buttons.md
+++ b/docs/_components/buttons.md
@@ -9,6 +9,8 @@ subnav:
     href: "#other-buttons"
 ---
 
+{% include helpers/base-component.html component="button" stylesheet="buttons" %}
+
 ## Standard Buttons
 
 Use the standard button styles to convey the most important action on you want the users to take. For actions outside of the top two actions, use the [other buttons](#other-buttons). See the [USWDS Button Usage](https://v2.designsystem.digital.gov/components/button/) for more on how to use buttons.

--- a/docs/_components/form-fields.md
+++ b/docs/_components/form-fields.md
@@ -17,6 +17,8 @@ subnav:
     href: "#form-validation-errors"
 ---
 
+{% include helpers/base-component.html component="form-controls" stylesheet="inputs" %}
+
 ## Text
 
 {% capture example %}

--- a/docs/_includes/helpers/base-component.html
+++ b/docs/_includes/helpers/base-component.html
@@ -1,0 +1,11 @@
+{% assign stylesheet = include.stylesheet | default: include.component %}
+{% assign uswds_url = include.component | append: '/' | prepend: 'https://designsystem.digital.gov/components/' %}
+{% assign sass_url = stylesheet | append: '.scss' | prepend: 'https://github.com/18F/identity-style-guide/blob/main/src/scss/components/_' %}
+
+<a href="{{ uswds_url }}" class="usa-link usa-link--external margin-bottom-2">
+  View USWDS component
+</a>
+
+<a href="{{ sass_url }}" class="usa-link usa-link--external">
+  View login.gov SCSS on GitHub
+</a>


### PR DESCRIPTION
**Why**: As someone using the login.gov Design System, I want to know when a component is implemented as an extension of the U.S. Web Design System, so that I can reference guidance from the USWDS documentation, and see specific implementation differences contained in the component stylesheet.

(Design has been roughly adapted from Summit Hackathon Figma document)

**Screenshot:**

![image](https://user-images.githubusercontent.com/1779930/105853824-1e2dc480-5fb4-11eb-9d90-54e4034c0479.png)
