### PR TITLE
Fix prose sibling heading margin selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix an issue where builds may produce styles in an unpredictable order.
 - Fix an issue where `.usa-display` heading font size was rendered larger than intended.
 - Fix an issue where `dropdownButton` was using invalid CommonJS syntax when imported from ES module entrypoint.
+- Fix an issue where `.usa-prose` heading margins were not applied consistently.
 
 ### Internal
 

--- a/src/scss/components/_typography.scss
+++ b/src/scss/components/_typography.scss
@@ -13,32 +13,37 @@
     letter-spacing: -0.2px;
   }
 
-  h2, h3 {
-    * + & {
-      margin-top: 1.7em;
-    }
+  * + h2,
+  * + h3 {
+    margin-top: 1.7em;
   }
+
   h4 {
     letter-spacing: -0.1px;
-
-    * + & {
-      margin-top: 2.5em;
-    }
   }
+
+  * + h4 {
+    margin-top: 2.5em;
+  }
+
   h5, h6 {
     @include u-font-family('sans');
     text-transform: uppercase;
 
-    * + & {
-      margin-top: 3em;
-    }
     + * {
       margin-top: 0.2em;
     }
   }
+
+  * + h5,
+  * + h6 {
+    margin-top: 3em;
+  }
+
   h5 {
     letter-spacing: 0.2px;
   }
+
   h6 {
     @include u-font-size('sans', 'micro');
     @include u-font-weight('bold');


### PR DESCRIPTION
**Why**: It's assumed _(confirmation needed)_ that the intention of these selectors was to match headings within `.usa-prose` following any other content in that prose block. Instead, due to the behavior of `&` in expanding the full selector ancestry, the generated output was along the lines of...

```
*+.usa-prose>h2,*+.usa-prose>h3 {
    margin-top: 1.7em
}
```

This can be interpreted as "a heading within a prose block, where the prose block itself is preceded by any other content".

This is expected to have a visual impact on headings in prose content. Example, from the ["Typography" page](https://design.login.gov/typography/):

Before|After
---|---
![before](https://user-images.githubusercontent.com/1779930/106295271-36a11780-621e-11eb-9da3-3afd67bcdba0.png)|![after](https://user-images.githubusercontent.com/1779930/106295239-2e48dc80-621e-11eb-86ba-7f3250426ac7.png)

Given that this styling has existed for quite a while, it may be worth reevaluating if the margins are still desirable.