### PR TITLE
Fix native ES module subpath resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fix an issue where `.usa-display` heading font size was rendered larger than intended.
 - Fix an issue where `dropdownButton` was using invalid CommonJS syntax when imported from ES module entrypoint.
 - Fix an issue where `.usa-prose` heading margins were not applied consistently.
+- Fix an issue where importing subpaths may not resolve correctly using native ES modules.
 
 ### Internal
 

--- a/package.json
+++ b/package.json
@@ -5,8 +5,24 @@
   "main": "./build/cjs/index.js",
   "module": "./build/esm/index.js",
   "exports": {
-    "require": "./build/cjs/index.js",
-    "import": "./build/esm/index.js"
+    ".": {
+      "require": "./build/cjs/index.js",
+      "import": "./build/esm/index.js"
+    },
+    "./auto": {
+      "require": "./build/cjs/auto.js",
+      "import": "./build/esm/auto.js"
+    },
+    "./build/cjs/auto": "./build/cjs/auto.js",
+    "./build/cjs/auto.js": "./build/cjs/auto.js",
+    "./build/cjs/index": "./build/cjs/index.js",
+    "./build/cjs/index.js": "./build/cjs/index.js",
+    "./build/esm/auto": "./build/esm/auto.js",
+    "./build/esm/auto.js": "./build/esm/auto.js",
+    "./build/esm/index": "./build/esm/index.js",
+    "./build/esm/index.js": "./build/esm/index.js",
+    "./dist/assets/js/main": "./dist/assets/js/main.js",
+    "./dist/assets/js/main.js": "./dist/assets/js/main.js"
   },
   "sideEffects": false,
   "scripts": {


### PR DESCRIPTION
Regression introduced in: #165

**Why**: So that projects importing subpaths from identity-style-guide don't fail if they respect native ES module `exports` definitions.

See: https://nodejs.org/api/packages.html#packages_package_entry_points

Specifically, the problem being fixed is one explicitly described in the above documentation:

>**Warning**: Introducing the `"exports"` field prevents consumers of a package from using any entry points that are not defined, including the `package.json` (e.g. `require('your-package/package.json')`. **This will likely be a breaking change.**

The intent with these changes is to allow for easier upgrades in projects which may be importing one of these paths ([example](https://github.com/18F/identity-site/blob/1bff268dbffe6b50affc513ba9c9097d942ba5bb/assets/js/main.js#L3)).

Co-Authored-By: Jessica Dembe <17969963+jmdembe@users.noreply.github.com>