### PR TITLE
LG-4226: Improve support for unstyled button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Link hover and active colors are now distinct.
   - Before: Hover and active colors are both `primary-darker`.
   - After: Hover is `primary-dark`, and active is `primary-darker`.
+- Improved support for "Unstyled" button variant ([see documentation](https://design.login.gov/components/buttons/))
 
 ### Bug Fixes
 

--- a/docs/_components/buttons.md
+++ b/docs/_components/buttons.md
@@ -13,7 +13,7 @@ subnav:
 
 Use the standard button styles to convey the most important action on you want the users to take. See the [USWDS Button Usage](https://v2.designsystem.digital.gov/components/button/) for more on how to use buttons.
 
-##### Primary
+### Primary
 
 ```html
 <button class="usa-button">
@@ -25,7 +25,7 @@ Use the standard button styles to convey the most important action on you want t
 <button class="usa-button usa-focus">Focus</button>
 <button class="usa-button" disabled>Disabled</button>
 
-##### Secondary
+### Secondary
 
 ```html
 <button class="usa-button usa-button--outline">
@@ -37,7 +37,7 @@ Use the standard button styles to convey the most important action on you want t
 <button class="usa-button usa-button--outline usa-focus">Focus</button>
 <button class="usa-button usa-button--outline" disabled>Disabled</button>
 
-##### Danger
+### Danger
 
 ```html
 <button class="usa-button usa-button--danger">
@@ -49,7 +49,7 @@ Use the standard button styles to convey the most important action on you want t
 <button class="usa-button usa-button--danger usa-focus">Focus</button>
 <button class="usa-button usa-button--danger" disabled>Disabled</button>
 
-##### Unstyled
+### Unstyled
 
 ```html
 <button class="usa-button usa-button--unstyled">

--- a/docs/_components/buttons.md
+++ b/docs/_components/buttons.md
@@ -48,3 +48,17 @@ Use the standard button styles to convey the most important action on you want t
 <button class="usa-button usa-button--danger usa-button--active">Active</button>
 <button class="usa-button usa-button--danger usa-focus">Focus</button>
 <button class="usa-button usa-button--danger" disabled>Disabled</button>
+
+##### Unstyled
+
+```html
+<button class="usa-button usa-button--unstyled">
+```
+
+<div>
+  {% include helpers/unstyled-button.html text="Default" %}
+  {% include helpers/unstyled-button.html text="Hover" extra_classes="usa-button--hover" %}
+  {% include helpers/unstyled-button.html text="Active" extra_classes="usa-button--active" %}
+  {% include helpers/unstyled-button.html text="Focus" extra_classes="usa-focus" %}
+  {% include helpers/unstyled-button.html text="Disabled" extra_attributes="disabled" %}
+</div>

--- a/docs/_includes/helpers/unstyled-button.html
+++ b/docs/_includes/helpers/unstyled-button.html
@@ -1,0 +1,16 @@
+{% comment %}
+This component displays an unstyled button, staged as if it has dimensions of a styled button, for
+the purpose of aligning button previews amongst other variants.
+{% endcomment %}
+
+<span style="position: relative; display: inline-flex;">
+  <button class="usa-button" disabled hidden style="visibility: hidden;">{{ include.text }}</button>
+  <span style="position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%); padding-right: 0.5rem;">
+    <button
+      class="usa-button usa-button--unstyled {{ include.extra_classes }}"
+      {{ include.extra_attributes }}
+    >
+      {{ include.text }}
+    </button>
+  </span>
+</span>

--- a/docs/_includes/helpers/unstyled-button.html
+++ b/docs/_includes/helpers/unstyled-button.html
@@ -3,14 +3,14 @@ This component displays an unstyled button, staged as if it has dimensions of a 
 the purpose of aligning button previews amongst other variants.
 {% endcomment %}
 
-<span style="position: relative; display: inline-flex;">
+<span class="display-block mobile-lg:display-inline-flex position-relative">
   <button class="usa-button" disabled hidden style="visibility: hidden;">{{ include.text }}</button>
-  <span style="position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%); padding-right: 0.5rem;">
+  <div class="position-absolute pin-all padding-right-1 display-flex flex-align-center flex-justify-center">
     <button
       class="usa-button usa-button--unstyled {{ include.extra_classes }}"
       {{ include.extra_attributes }}
     >
       {{ include.text }}
     </button>
-  </span>
+  </div>
 </span>

--- a/src/scss/components/_buttons.scss
+++ b/src/scss/components/_buttons.scss
@@ -27,6 +27,50 @@
   }
 }
 
+.usa-button--unstyled {
+  position: relative;
+  text-underline-offset: 3px;
+
+  // In USWDS, unstyled button styles are applied last to take precedence over base button styles.
+  // Since we override base button styles, we must re-apply the unstyled button styles.
+  &.usa-button {
+    @include button-unstyled;
+  }
+
+  // Hover colors are already applied by USWDS via `typeset-link`, but this does not include the
+  // button modifier classes.
+  &:hover,
+  &.usa-button--hover {
+    color: color($theme-link-hover-color);
+  }
+
+  &:active,
+  &.usa-button--active {
+    color: color($theme-link-active-color);
+  }
+
+  &:disabled {
+    color: color('disabled');
+  }
+
+  &.usa-button:not([disabled]):focus,
+  &.usa-button:not([disabled]).usa-focus {
+    box-shadow: none;
+
+    &::before {
+      border-radius: .125rem;
+      bottom: -5px;
+      box-shadow: 0 0 0 $theme-focus-width color($theme-focus-color);
+      content: '';
+      left: -5px;
+      pointer-events: none;
+      position: absolute;
+      right: -5px;
+      top: -5px;
+    }
+  }
+}
+
 .usa-button:not([disabled]):focus,
 .usa-button:not([disabled]).usa-focus {
   @include disable-default-focus-styles;


### PR DESCRIPTION
The unstyled button variant had previously existed in that it was inherited from USWDS, though it was not documented, and did not always display correctly, particularly in hover, active, and focus states. These changes improve this support, and adds documentation for the unstyled option.

**Screenshot:**

![unstyled button](https://user-images.githubusercontent.com/1779930/109178623-0bdfab80-7757-11eb-9888-a6300b27be45.png)

**Live Preview:** https://federalist-2f194a10-945e-4413-be01-46ca6dae5358.app.cloud.gov/preview/18f/identity-style-guide/aduth-lg-4226-document-variants/components/buttons/