### PR TITLE
LG-4226: Add wide button variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   - Before: Hover and active colors are both `primary-darker`.
   - After: Hover is `primary-dark`, and active is `primary-darker`.
 - Improved support for "Unstyled" button variant ([see documentation](https://design.login.gov/components/buttons/))
+- Add two new wide-width button variants `usa-button--wide` and `usa-button--full-width`.
 
 ### Bug Fixes
 

--- a/docs/_components/buttons.md
+++ b/docs/_components/buttons.md
@@ -81,7 +81,7 @@ Default button width for desktop viewports.
 
 ### Minimum width
 
-Use to set a minimum button width for desktop viewports.
+Use `usa-button--wide` to set a minimum button width for desktop viewports.
 
 ```html
 <button class="usa-button usa-button--wide">
@@ -94,6 +94,8 @@ Use to set a minimum button width for desktop viewports.
 ### Full width
 
 All buttons default to full width for mobile viewports.
+
+Use `usa-button--full-width` to set full-width buttons for desktop viewports.
 
 ```html
 <button class="usa-button use-button--full-width">

--- a/docs/_components/buttons.md
+++ b/docs/_components/buttons.md
@@ -5,6 +5,8 @@ lead: >
 subnav:
   - text: Standard Buttons
     href: "#standard-buttons"
+  - text: Button Widths
+    href: "#button-widths"
 ---
 
 {% include helpers/base-component.html component="button" stylesheet="buttons" %}
@@ -62,3 +64,41 @@ Use the standard button styles to convey the most important action on you want t
   {% include helpers/unstyled-button.html text="Focus" extra_classes="usa-focus" %}
   {% include helpers/unstyled-button.html text="Disabled" extra_attributes="disabled" %}
 </div>
+
+## Button Widths
+
+### Flexible width
+
+Default button width for desktop viewports.
+
+```html
+<button class="usa-button">
+```
+
+<button class="usa-button">Default</button>
+
+<button class="usa-button usa-button--big">Default</button>
+
+### Minimum width
+
+Use to set a minimum button width for desktop viewports.
+
+```html
+<button class="usa-button usa-button--wide">
+```
+
+<button class="usa-button usa-button--wide">Default</button>
+
+<button class="usa-button usa-button--wide usa-button--big">Default</button>
+
+### Full width
+
+All buttons default to full width for mobile viewports.
+
+```html
+<button class="usa-button use-button--full-width">
+```
+
+<button class="usa-button usa-button--full-width">Default</button>
+
+<button class="usa-button usa-button--full-width usa-button--big">Default</button>

--- a/src/scss/components/_buttons.scss
+++ b/src/scss/components/_buttons.scss
@@ -153,6 +153,20 @@
   }
 }
 
+.usa-button--wide {
+  @include at-media-max('tablet') {
+    width: 100%;
+  }
+
+  @include at-media('tablet') {
+    min-width: 14rem;
+  }
+}
+
+.usa-button--full-width {
+  width: 100%;
+}
+
 .usa-form a.usa-button.usa-button--danger { /* stylelint-disable-line selector-no-qualifying-type */
   color: color('white');
   text-decoration: none;

--- a/src/scss/components/_buttons.scss
+++ b/src/scss/components/_buttons.scss
@@ -154,10 +154,6 @@
 }
 
 .usa-button--wide {
-  @include at-media-max('tablet') {
-    width: 100%;
-  }
-
   @include at-media('tablet') {
     min-width: 14rem;
   }

--- a/src/scss/components/_buttons.scss
+++ b/src/scss/components/_buttons.scss
@@ -154,7 +154,7 @@
 }
 
 .usa-button--wide {
-  @include at-media('tablet') {
+  @include at-media('mobile-lg') {
     min-width: 14rem;
   }
 }


### PR DESCRIPTION
Adds two new button variants:

1. Minimum width occupies full width on mobile, and a minimum width on wider viewports
2. Full width always occupies full width

**Questions:** (cc @anniehirshman-gsa)

1. The Figma includes text "All buttons default to full width for mobile viewports". Should this behavior apply to the unmodified `usa-button` ("flexible") button, or only minimum-width and full-size buttons?
2. The Figma mentions using `btn-wide` as the class for a minimum width button. As implemented here, I chose to follow the BEM convention as `usa-button--wide`. Is that okay?
3. What specific breakpoint should mobile behavior stop taking effect ([see USWDS "Utility breakpoints"](https://designsystem.digital.gov/documentation/settings/#utilities-settings))? As implemented here is `tablet`.
4. I included an explicit `usa-button--full-width` modifier to handle cases like in the IDP where we want full-width buttons on desktop viewports. Is that reasonable to include here, or should that be considered an exceptional case and custom to the IDP?

**Screenshot:**

![button widths](https://user-images.githubusercontent.com/1779930/109201224-946a4600-776f-11eb-8bc5-69a658b5b6cf.png)

**Live Preview:** https://federalist-2f194a10-945e-4413-be01-46ca6dae5358.app.cloud.gov/preview/18f/identity-style-guide/aduth-lg-4226-wide-button/components/buttons/#button-widths