### PR TITLE
LG-4226: Document current button offerings ("big", "outline")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### Documentation
 
+- Add documentation for "Big" button variants.
 - Rename "Secondary" as "Outline" in buttons documentation.
 
 ## 4.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
 - Fix an issue where focused buttons appear with a double focus ring style.
 - Fix an issue where using the "auto" package entrypoint may cause components not to be loaded when used with some bundlers (e.g. Webpack).
 
+### Documentation
+
+- Rename "Secondary" as "Outline" in buttons documentation.
+
 ## 4.0.0
 
 ### Breaking Changes

--- a/docs/_components/buttons.md
+++ b/docs/_components/buttons.md
@@ -27,7 +27,7 @@ Use the standard button styles to convey the most important action on you want t
 <button class="usa-button usa-focus">Focus</button>
 <button class="usa-button" disabled>Disabled</button>
 
-### Secondary
+### Outline
 
 ```html
 <button class="usa-button usa-button--outline">

--- a/docs/_components/buttons.md
+++ b/docs/_components/buttons.md
@@ -3,17 +3,17 @@ title: Buttons
 lead: >
   Use buttons to signal actions.
 subnav:
-  - text: Standard Buttons
-    href: "#standard-buttons"
-  - text: Button Widths
+  - text: Button sizes and states
+    href: "#button-sizes-and-states"
+  - text: Button widths
     href: "#button-widths"
 ---
 
 {% include helpers/base-component.html component="button" stylesheet="buttons" %}
 
-## Standard Buttons
+## Button sizes and states
 
-Use the standard button styles to convey the most important action on you want the users to take. See the [USWDS Button Usage](https://v2.designsystem.digital.gov/components/button/) for more on how to use buttons.
+### Default
 
 ### Primary
 
@@ -65,7 +65,65 @@ Use the standard button styles to convey the most important action on you want t
   {% include helpers/unstyled-button.html text="Disabled" extra_attributes="disabled" %}
 </div>
 
-## Button Widths
+### Big
+
+### Primary
+
+```html
+<button class="usa-button usa-button--big">
+```
+
+<div>
+  <button class="usa-button usa-button--big">Default</button>
+  <button class="usa-button usa-button--big usa-button--hover">Hover</button>
+  <button class="usa-button usa-button--big usa-button--active">Active</button>
+  <button class="usa-button usa-button--big usa-focus">Focus</button>
+  <button class="usa-button usa-button--big" disabled>Disabled</button>
+</div>
+
+### Outline
+
+```html
+<button class="usa-button usa-button--big usa-button--outline">
+```
+
+<div>
+  <button class="usa-button usa-button--big usa-button--outline">Default</button>
+  <button class="usa-button usa-button--big usa-button--outline usa-button--hover">Hover</button>
+  <button class="usa-button usa-button--big usa-button--outline usa-button--active">Active</button>
+  <button class="usa-button usa-button--big usa-button--outline usa-focus">Focus</button>
+  <button class="usa-button usa-button--big usa-button--outline" disabled>Disabled</button>
+</div>
+
+### Danger
+
+```html
+<button class="usa-button usa-button--big usa-button--danger">
+```
+
+<div>
+  <button class="usa-button usa-button--big usa-button--danger">Default</button>
+  <button class="usa-button usa-button--big usa-button--danger usa-button--hover">Hover</button>
+  <button class="usa-button usa-button--big usa-button--danger usa-button--active">Active</button>
+  <button class="usa-button usa-button--big usa-button--danger usa-focus">Focus</button>
+  <button class="usa-button usa-button--big usa-button--danger" disabled>Disabled</button>
+</div>
+
+### Unstyled
+
+```html
+<button class="usa-button usa-button--unstyled">
+```
+
+<div>
+  {% include helpers/unstyled-button.html text="Default" extra_classes="usa-button--big" %}
+  {% include helpers/unstyled-button.html text="Hover" extra_classes="usa-button--hover usa-button--big" %}
+  {% include helpers/unstyled-button.html text="Active" extra_classes="usa-button--active usa-button--big" %}
+  {% include helpers/unstyled-button.html text="Focus" extra_classes="usa-focus usa-button--big" %}
+  {% include helpers/unstyled-button.html text="Disabled" extra_attributes="disabled" extra_classes="usa-button--big" %}
+</div>
+
+## Button widths
 
 ### Flexible width
 

--- a/docs/_includes/helpers/unstyled-button.html
+++ b/docs/_includes/helpers/unstyled-button.html
@@ -4,7 +4,14 @@ the purpose of aligning button previews amongst other variants.
 {% endcomment %}
 
 <span class="display-block mobile-lg:display-inline-flex position-relative">
-  <button class="usa-button" disabled hidden style="visibility: hidden;">{{ include.text }}</button>
+  <button
+    class="usa-button {{ include.extra_classes }}"
+    disabled
+    hidden
+    style="visibility: hidden;"
+  >
+    {{ include.text }}
+  </button>
   <div class="position-absolute pin-all padding-right-1 display-flex flex-align-center flex-justify-center">
     <button
       class="usa-button usa-button--unstyled {{ include.extra_classes }}"

--- a/src/scss/components/_buttons.scss
+++ b/src/scss/components/_buttons.scss
@@ -1,31 +1,10 @@
 .usa-button {
   line-height: 1;
 
-  &:visited {
-    color: color('white');
-  }
-
-  &:hover,
-  &.usa-button--hover {
-    background-color: color('primary-dark');
-    border-bottom: 0;
-    color: color('white');
-    text-decoration: none;
-  }
-
-  &:active,
-  &.usa-button--active {
-    background-color: color('primary-darker');
-    color: color('white');
-  }
-
   &:not([disabled]):focus,
   &:not([disabled]).usa-focus {
-    outline-offset: units(0.5);
-  }
-
-  &:disabled {
-    @include button-disabled;
+    @include disable-default-focus-styles;
+    box-shadow: roundable-focus-outline-box-shadows();
   }
 }
 
@@ -73,12 +52,6 @@
   }
 }
 
-.usa-button:not([disabled]):focus,
-.usa-button:not([disabled]).usa-focus {
-  @include disable-default-focus-styles;
-  box-shadow: roundable-focus-outline-box-shadows();
-}
-
 .usa-button--secondary,
 .usa-button--outline {
   background-color: color('white');
@@ -97,13 +70,11 @@
   &:hover,
   &.usa-button--hover {
     background-color: color('primary-lightest');
-    color: color('primary');
   }
 
   &:active,
   &.usa-button--active {
     background-color: color('primary-lighter');
-    color: color('primary');
   }
 
   &:disabled,

--- a/src/scss/components/_buttons.scss
+++ b/src/scss/components/_buttons.scss
@@ -167,6 +167,7 @@
 
 .usa-button--big {
   @include u-padding-x('205');
+  border-radius: units(1);
   font-size: 1.25rem;
 }
 

--- a/src/scss/components/_buttons.scss
+++ b/src/scss/components/_buttons.scss
@@ -1,4 +1,6 @@
 .usa-button {
+  line-height: 1;
+
   &:visited {
     color: color('white');
   }
@@ -161,6 +163,11 @@
 
 .usa-button--full-width {
   width: 100%;
+}
+
+.usa-button--big {
+  @include u-padding-x('205');
+  font-size: 1.25rem;
 }
 
 .usa-form a.usa-button.usa-button--danger { /* stylelint-disable-line selector-no-qualifying-type */


### PR DESCRIPTION
This pull request...

- Updates Buttons page to include Big button examples.
- Small adjustments to Big button sizing per Figma design (padding, font size, line height).
- Renames "Secondary" button to "Outline" button
   - Note: In code, "Secondary" still exists, and is effectively aliased as the outline button. This is how it was implemented previously, and otherwise we'd inherit USWDS secondary button styling, which may not be desirable or at least not predictable in its usage.

Note: Between this and #191, whichever is merged first, the other should include and verify the behavior of the unstyled, big button. I tested this locally and it appeared to work reasonably well out of the box.

**Screenshot:**

![Big Buttons](https://user-images.githubusercontent.com/1779930/109342296-a0223f00-7839-11eb-979a-f4717941b167.png)

**Live Preview:** https://federalist-2f194a10-945e-4413-be01-46ca6dae5358.app.cloud.gov/preview/18f/identity-style-guide/aduth-lg-4226-document-outline-big/components/buttons/