### PR TITLE
Fix sideEffects package configuration for "auto" entrypoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Bug Fixes
 
 - Fix an issue where focused buttons appear with a double focus ring style.
+- Fix an issue where using the "auto" package entrypoint may cause components not to be loaded when used with some bundlers (e.g. Webpack).
 
 ## 4.0.0
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,10 @@
     "./dist/assets/js/main": "./dist/assets/js/main.js",
     "./dist/assets/js/main.js": "./dist/assets/js/main.js"
   },
-  "sideEffects": false,
+  "sideEffects": [
+    "./dist/assets/js/main.js",
+    "./build/*/auto.js"
+  ],
   "scripts": {
     "start": "make start",
     "clean": "make clean",


### PR DESCRIPTION
The package uses `sideEffects` along with ES Module `exports` to allow consuming projects to optimize the amount of code generated when using individual components from the package, via dead-code elimination / ["tree shaking"](https://webpack.js.org/guides/tree-shaking/). `sideEffects` instructs the bundler that there are no side-effects in importing the code, and that it's safe to discard code except for direct references to exported members.

However, this project also distributes an "auto" version, which is intended to automatically handle initialization for all components simply by being loaded:

```js
import 'identity-style-guide/auto';
```

This requires side effects, and therefore must be made an exception by passing paths as an array to `sideEffects` ([see documentation](https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free)). Otherwise, no code will be loaded since Webpack will assume it's safe to eliminate all unreferenced exports, and since there are no referenced exports, all code would be omitted.

In the meantime, projects using the current published version can work around this by configuring Webpack to override the package's default `sideEffects` value ([reference](https://github.com/webpack/webpack/issues/6065#issuecomment-351060570)):

```js
module.rules: [
  {
    include: path.resolve('node_modules', 'identity-style-guide'),
    sideEffects: true
  }
]
```