### PR TITLE
Change link hover color from "primary-darker" to "primary-dark"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
   - Small (`usa-button--small`)
   - Tiny (`usa-button--tiny`)
 
+### Improvements
+
+- Link hover and active colors are now distinct.
+  - Before: Hover and active colors are both `primary-darker`.
+  - After: Hover is `primary-dark`, and active is `primary-darker`.
+
 ### Bug Fixes
 
 - Fix an issue where focused buttons appear with a double focus ring style.

--- a/src/scss/uswds-theme/_color.scss
+++ b/src/scss/uswds-theme/_color.scss
@@ -198,5 +198,5 @@ $theme-banner-background-color: 'primary-lighter';
 // Links
 $theme-link-color:             'primary';
 $theme-link-visited-color:     'violet-70v';
-$theme-link-hover-color:       'primary-darker';
+$theme-link-hover-color:       'primary-dark';
 $theme-link-active-color:      'primary-darker';


### PR DESCRIPTION
For context, see: https://github.com/18F/identity-style-guide/pull/191/files#r582962658

Active color is left unchanged as `primary-darker`.