### PR TITLE
LG-4226: Add explicit flexible width button modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@
   - Before: Hover and active colors are both `primary-darker`.
   - After: Hover is `primary-dark`, and active is `primary-darker`.
 - Improved support for "Unstyled" button variant ([see documentation](https://design.login.gov/components/buttons/))
-- Add two new wide-width button variants `usa-button--wide` and `usa-button--full-width`.
+- Add three new button variants to control width:
+  - `usa-button--wide` displays a button at a wider (minimum) width at larger viewport displays.
+  - `usa-button--flexible-width` displays a button at flexible width regardless of viewport size, and overrides default mobile appearance of full-width buttons.
+  - `usa-button--full-width` displays a button at full width regardless of viewport size, and overrides default desktop appearance of flexible-width buttons.
 
 ### Bug Fixes
 

--- a/docs/_components/buttons.md
+++ b/docs/_components/buttons.md
@@ -137,6 +137,16 @@ Default button width for desktop viewports.
 
 <button class="usa-button usa-button--big">Default</button>
 
+Use `usa-button--flexible-width` to set flexible width buttons for mobile.
+
+```html
+<button class="usa-button usa-button--flexible-width">
+```
+
+<button class="usa-button usa-button--flexible-width">Default</button>
+
+<button class="usa-button usa-button--flexible-width usa-button--big">Default</button>
+
 ### Minimum width
 
 Use `usa-button--wide` to set a minimum button width for desktop viewports.

--- a/src/scss/components/_buttons.scss
+++ b/src/scss/components/_buttons.scss
@@ -126,6 +126,10 @@
   }
 }
 
+.usa-button--flexible-width {
+  width: auto;
+}
+
 .usa-button--wide {
   @include at-media('mobile-lg') {
     min-width: 14rem;


### PR DESCRIPTION
**Why**: As a consumer of the login.gov Design System, I expect to be able to override the default full-width button appearance on mobile to allow for flexible-width buttons, so that I can create interfaces where the button is shown adjacent to other text or controls.

Currently, all buttons are shown as full-width at mobile viewports. There are a few instances in the IDP of buttons appearing as flexible width at mobile viewport sizes, with text or interactive content shown next to the button ([example](https://user-images.githubusercontent.com/1779930/109558515-88e88900-7aa7-11eb-9148-b5c0c6d7b62c.png)). These are not the majority, so an override option is included to let the developer choose to force the width to shrink as flexible, while retaining the current default behavior.

In discussing this with @anniehirshman-gsa , it was considered whether a similar exception override class should be included for minimum-width buttons (e.g. `usa-button--minimum-width`). There are currently no use-cases for this, so it was decided to defer this for future consideration if ever it becomes relevant.

**Live Preview:** https://federalist-2f194a10-945e-4413-be01-46ca6dae5358.app.cloud.gov/preview/18f/identity-style-guide/aduth-mobile-flex-width-button/components/buttons/#button-widths

**Screenshot:**

![image](https://user-images.githubusercontent.com/1779930/109558423-65254300-7aa7-11eb-8cd1-34d6bfa1628d.png)
