### PR TITLE
LG-4226: Fix double focus ring on unstyled buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 5.0.1
+
+### Bug Fixes
+
+- Fix an issue where a second focus ring effect was still applied to the unstyled button variant.
+
 ## 5.0.0
 
 ### Breaking Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "identity-style-guide",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "identity-style-guide",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "The global style of login.gov",
   "main": "./build/cjs/index.js",
   "module": "./build/esm/index.js",

--- a/src/scss/components/_buttons.scss
+++ b/src/scss/components/_buttons.scss
@@ -12,10 +12,20 @@
   position: relative;
   text-underline-offset: 3px;
 
-  // In USWDS, unstyled button styles are applied last to take precedence over base button styles.
-  // Since we override base button styles, we must re-apply the unstyled button styles.
-  &.usa-button {
-    @include button-unstyled;
+  // USWDS currently only sets hover and active unstyled button styles for the browser-native
+  // states, and not with the modifier classes. It also does not apply these styles to the disabled
+  // button, allowing some background color to bleed through. These overrides may be removed if an
+  // upstream fix is merged.
+  //
+  // See: https://github.com/uswds/uswds/pull/4077
+  &.usa-button--hover,
+  &.usa-button--active,
+  &:disabled,
+  &.usa-button--disabled {
+    @include no-knockout-font-smoothing;
+    background-color: transparent;
+    box-shadow: none;
+    text-decoration: underline;
   }
 
   // Hover colors are already applied by USWDS via `typeset-link`, but this does not include the

--- a/src/scss/components/_buttons.scss
+++ b/src/scss/components/_buttons.scss
@@ -8,7 +8,16 @@
   }
 }
 
+.usa-button--big {
+  @include u-padding-x('205');
+  border-radius: units(1);
+  font-size: 1.25rem;
+}
+
 .usa-button--unstyled {
+  // In USWDS, unstyled button styles are applied last to take precedence over base button styles.
+  // Since we override base button styles, we must re-apply the unstyled button styles.
+  @include button-unstyled;
   position: relative;
   text-underline-offset: 3px;
 
@@ -148,12 +157,6 @@
 
 .usa-button--full-width {
   width: 100%;
-}
-
-.usa-button--big {
-  @include u-padding-x('205');
-  border-radius: units(1);
-  font-size: 1.25rem;
 }
 
 .usa-form a.usa-button.usa-button--danger { /* stylelint-disable-line selector-no-qualifying-type */


### PR DESCRIPTION
Regression of #193 (69a13a0342ae871cac8383e138d4b603b45f4d04).

**Why**: For consistency with other buttons and to align to expected design specs, there should only be a single outline on any focussed button.

Before|After
---|---
![before](https://user-images.githubusercontent.com/1779930/110644903-8c54d200-8183-11eb-9d39-f5ce8545b824.png)|![after](https://user-images.githubusercontent.com/1779930/110644862-8232d380-8183-11eb-9c79-16dad57a889b.png)

**Live Preview:** https://federalist-2f194a10-945e-4413-be01-46ca6dae5358.app.cloud.gov/preview/18f/identity-style-guide/aduth-fix-unstyled-focus/components/buttons/

**Implementation Notes:**

Refactoring in #193 rearranged styles such that [our re-application of the unstyled mixin](https://github.com/18F/identity-style-guide/blob/8a6b48308f27cf7f6b75df54cdc50981f3708722/src/scss/components/_buttons.scss#L15-L19) would reintroduce focus styles through [the mixin's use of link styles](https://github.com/uswds/uswds/blob/0c95fd94ecdb646f360592aa01c55dc386ce407b/src/stylesheets/core/mixins/_button-unstyled.scss#L3). Ultimately, including this mixin should not be necessary, because USWDS handles hover and active unstyled states, but does not currently do so for the modifier classes (see https://github.com/uswds/uswds/pull/4077). Previously, we worked around this by including the unstyled button mixin, which would have a higher specificity than the default button's hover styles. Unfortunately, this also comes with some unexpected consequences, such as the [re-application of the USWDS focus ring](https://github.com/uswds/uswds/blob/0c95fd94ecdb646f360592aa01c55dc386ce407b/src/stylesheets/core/mixins/_typography.scss#L75-L77), which we expect to override in [our own default button styles](https://github.com/18F/identity-style-guide/blob/8a6b48308f27cf7f6b75df54cdc50981f3708722/src/scss/components/_buttons.scss#L4-L8).

This branch includes a bump to the patch version of the package, with the expectation that a new package will be published immediately following merge.