### PR TITLE
Buttons: Improve unstyled button styles to visually match link appearance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 5.0.2
+
+### Bug Fixes
+
+- Fix an issue where unstyled buttons may appear heavier than an equivalent link.
+
 ## 5.0.1
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bug Fixes
 
-- Fix an issue where unstyled buttons may appear heavier than an equivalent link.
+- Fix the appearance of unstyled buttons to appear visually identical to a link.
 
 ## 5.0.1
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "identity-style-guide",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "identity-style-guide",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "The global style of login.gov",
   "main": "./build/cjs/index.js",
   "module": "./build/esm/index.js",

--- a/src/scss/components/_buttons.scss
+++ b/src/scss/components/_buttons.scss
@@ -31,7 +31,8 @@
   &.usa-button--active,
   &:disabled,
   &.usa-button--disabled {
-    @include no-knockout-font-smoothing;
+    -moz-osx-font-smoothing: inherit;
+    -webkit-font-smoothing: inherit;
     background-color: transparent;
     box-shadow: none;
     text-decoration: underline;

--- a/src/scss/components/_buttons.scss
+++ b/src/scss/components/_buttons.scss
@@ -19,7 +19,6 @@
   // Since we override base button styles, we must re-apply the unstyled button styles.
   @include button-unstyled;
   position: relative;
-  text-underline-offset: 3px;
 
   // USWDS currently only sets hover and active unstyled button styles for the browser-native
   // states, and not with the modifier classes. It also does not apply these styles to the disabled


### PR DESCRIPTION
Related Slack conversation: https://gsa-tts.slack.com/archives/CNCGEHG1G/p1616421634001700

**Why**: The use of an unstyled button is intended to take the visual appearance of a link. The proposed changes resolve some discrepancies that currently exist:

- Avoid customizing the underline offset
- Reset font smoothing using `inherit` (see https://github.com/uswds/uswds/pull/4115 for detail)

**Live Preview:** https://federalist-2f194a10-945e-4413-be01-46ca6dae5358.app.cloud.gov/preview/18f/identity-style-guide/aduth-unstyled-buttons-links/components/buttons/

**Screenshot:**

Before|After
---|---
![before](https://user-images.githubusercontent.com/1779930/112016068-bfdc1880-8b02-11eb-96ad-99f31eceb97a.png)|![after](https://user-images.githubusercontent.com/1779930/112016083-c2d70900-8b02-11eb-9877-cc31599b0a5f.png)

This was originally observed in the IdP, where an equivalent link and unstyled button did not appear the same. See examples below which show a real link on the left vs. an unstyled button on the right. The IdP customizes the default font smoothing of text, which currently causes a difference in appearance between links and unstyled buttons (see https://github.com/uswds/uswds/pull/4115). Separately, we should consider if this is actually something we should be doing, perhaps as part of the ongoing work to migrate to Public Sans font ([see related guidance](https://usabilitypost.com/2012/11/05/stop-fixing-font-smoothing/)).

IdP Before|IdP with underline offset fix|IdP with underline offset & smoothing fixes
---|---|---
![idp before](https://user-images.githubusercontent.com/1779930/112016290-f9ad1f00-8b02-11eb-9f53-6ba3d3b6358f.png)|![idp with underline fix](https://user-images.githubusercontent.com/1779930/112016339-0467b400-8b03-11eb-86b3-b3e75ab27718.png)|![idp with underline and smoothing fix](https://user-images.githubusercontent.com/1779930/112016391-0d588580-8b03-11eb-88ac-65e23ea37fe9.png)


