### PR TITLE
Apply inherited font smoothing to base unstyled button styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 5.0.3
+
+### Bug Fixes
+
+- Fix font weight appearance of unstyled buttons in content which applies anti-aliased font smoothing.
+
 ## 5.0.2
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "identity-style-guide",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "identity-style-guide",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "The global style of login.gov",
   "main": "./build/cjs/index.js",
   "module": "./build/esm/index.js",

--- a/src/scss/components/_buttons.scss
+++ b/src/scss/components/_buttons.scss
@@ -20,6 +20,13 @@
   @include button-unstyled;
   position: relative;
 
+  // If upstream USWDS changes are merged to revise default behavior of unstyled font smoothing
+  // reset, these styles could be safely removed.
+  //
+  // See: https://github.com/uswds/uswds/pull/4115
+  -moz-osx-font-smoothing: inherit;
+  -webkit-font-smoothing: inherit;
+
   // USWDS currently only sets hover and active unstyled button styles for the browser-native
   // states, and not with the modifier classes. It also does not apply these styles to the disabled
   // button, allowing some background color to bleed through. These overrides may be removed if an


### PR DESCRIPTION
**Why**: These were applied to modifier states for unstyled buttons in #201, but should have also been applied to the base styles, to override USWDS unstyled button styles.