### PR TITLE
Use aXe runner for pa11y-ci accessibility test

### DIFF
--- a/.pa11yci.js
+++ b/.pa11yci.js
@@ -5,5 +5,6 @@ module.exports = {
     },
     "concurrency": 10,
     "standard": "WCAG2AA",
+    "runners": ["axe"],
   }
 }


### PR DESCRIPTION
**Why**:

- Consistency with other Login.gov projects ([brochure site](https://github.com/18F/identity-site/blob/544acfd84ce6989710501a409feffa0f358be3ea/package.json#L32), [IdP](https://github.com/18F/identity-idp/blob/ce7608a50ea9f7b8d8c747c63cc0c49549eac4a7/Gemfile#L103), [dashboard](https://github.com/18F/identity-dashboard/blob/33e234da0263723a35eb9cf332f0fb5331bf940c/Gemfile#L75), [PKI](https://github.com/18F/identity-pki/blob/921c14ba9c5c3df83e5768b72f83b1ee9ca8e2df/Gemfile#L45)).
- More capable of finding issues not discovered by HTML_CodeSniffer ([the default runner](https://github.com/pa11y/pa11y#runners)) because it runs in a full browser, as opposed to doing a static analysis of HTML markup.

The second point is further evidenced by the fact that the build is expected to fail with these changes with a number of existing issues on the documentation site.

This work could also facilitate future effort to use `axe-core` directly, as we do in the brochure site, to eliminate the current duplicate dependency on Puppeteer.