### PR TITLE
Reduce border width on default outline button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 5.0.4
+
+### Bug Fixes
+
+- Reduce the border width of the normal outline button to the intended width of `1px` (previously `2px`). The big variant of the outline button is unaffected by this change, and remains `2px`.
+
 ## 5.0.3
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 5.0.4
+## Unreleased
 
 ### Bug Fixes
 

--- a/src/scss/components/_buttons.scss
+++ b/src/scss/components/_buttons.scss
@@ -1,3 +1,5 @@
+$button-stroke-big: inset 0 0 0 units($theme-button-stroke-width * 2);
+
 .usa-button {
   line-height: 1;
 
@@ -108,6 +110,44 @@
     background-color: color('white');
     box-shadow: $button-stroke color('disabled');
     color: color('disabled');
+  }
+
+  &.usa-button--big {
+    box-shadow: $button-stroke-big color('primary');
+
+    &:not([disabled]):focus,
+    &:not([disabled]).usa-focus {
+      box-shadow: $button-stroke-big color('primary'), roundable-focus-outline-box-shadows();
+    }
+
+    &:hover,
+    &.usa-button--hover {
+      box-shadow: $button-stroke-big color('primary-dark');
+    }
+
+    &:active,
+    &.usa-button--active {
+      box-shadow: $button-stroke-big color('primary-darker');
+    }
+
+    &:disabled,
+    &.usa-button--disabled {
+      box-shadow: $button-stroke-big color('disabled');
+    }
+
+    &.usa-button--inverse {
+      box-shadow: $button-stroke-big color('base-lighter');
+
+      &:hover,
+      &.usa-button--hover {
+        box-shadow: $button-stroke-big color($theme-link-reverse-hover-color);
+      }
+
+      &:active,
+      &.usa-button--active {
+        box-shadow: $button-stroke-big color($theme-link-reverse-active-color);
+      }
+    }
   }
 }
 

--- a/src/scss/uswds-theme/_components.scss
+++ b/src/scss/uswds-theme/_components.scss
@@ -31,6 +31,7 @@ $theme-banner-font-family:            'ui';
 $theme-button-font-family:            'ui';
 $theme-button-border-radius:          'md';
 $theme-button-small-width:            6;
+$theme-button-stroke-width:           1px;
 
 // Footer
 $theme-footer-font-family:            'body';


### PR DESCRIPTION
**Why**: Per Figma design reference, the outline button should only have a border width of 1px, not 2px. The "Big" outline button should still have a 2px border.

**Live Preview:** https://federalist-2f194a10-945e-4413-be01-46ca6dae5358.app.cloud.gov/preview/18f/identity-style-guide/aduth-outline-button-border-width/components/buttons/

**Screenshot:**

_Design System:_

Before|After
---|---
![before](https://user-images.githubusercontent.com/1779930/112851834-5798b400-9079-11eb-9773-e1fac49aa947.png)|![after](https://user-images.githubusercontent.com/1779930/112851560-17d1cc80-9079-11eb-8030-070e8818c9b9.png)

_IdP:_

Before|After
---|---
![before](https://user-images.githubusercontent.com/1779930/112852311-cece4800-9079-11eb-9be2-c0fe9b88dfed.png)|![after](https://user-images.githubusercontent.com/1779930/112852283-c970fd80-9079-11eb-89ff-ee40426df98e.png)

**Implementation Notes:**

USWDS allows customization of the stroke width of an outline button, but does not allow for different values between default and big versions of the button. Implementing this requires duplicating the base styles with a custom "big" stroke width, computed here as double the value of the new default stroke width of `1px`.