### PR TITLE
Fix build setup to be compatible with latest Federalist release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,6 @@ ifdef SITE_PREFIX
 	OUTPUT_DIR = ./_site
 endif
 
-install-jekyll: install-bundler
-	bundle check || bundle install
-
-install-bundler:
-	gem list -i bundler || gem install bundler
-
 start: start-docs start-assets
 
 start-docs:

--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ The following dependencies are required to build the documentation and assets wi
 - [Ruby](.ruby-version)
 - [Node.js](.nvmrc)
 
-After satisfying the above language dependencies and cloning this repository, install package dependencies with `npm`:
+After satisfying the above language dependencies and cloning this repository, install package dependencies:
 
 ```
 npm install
+bundle install
 ```
 
 In development, build the documentation site with assets, watch source files for changes, and serve the compiled site at [localhost:4000](http://localhost:4000) by running:

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test-pa11y": "make test-runner-pa11y",
     "test-jest": "make test-runner-jest",
     "build": "make build",
-    "federalist": "npm install && make build-assets",
+    "federalist": "make build-assets",
     "prepublishOnly": "make lint && make clean && make build-assets build-package"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "test-jest": "make test-runner-jest",
     "build": "make build",
     "federalist": "npm install && make build-assets",
-    "prepare": "make install-jekyll",
     "prepublishOnly": "make lint && make clean && make build-assets build-package"
   },
   "files": [


### PR DESCRIPTION
**Why**: Federalist will install all dependencies for us. Previously we needed to re-run the NPM install in order to install development dependencies in addition to production dependencies. As of the Federalist release this past Friday, it will install all dependencies, so this will no longer be necessary.

**Note:** All Federalist builds will fail until this pull request is merged.

Related discussion: https://gsa-tts.slack.com/archives/C1NUUGTT5/p1617287819021500