### PR TITLE
Load utility classes after components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Reduce the border width of the normal outline button to the intended width of `1px` (previously `2px`). The big variant of the outline button is unaffected by this change, and remains `2px`.
 - Fix rounded corners on sidebar current page item.
 - Fix unintentional rounded corners on search text field.
+- Fix utility classes not always applying as expected when applied to components. For example, using `margin-` utility classes on an unstyled button would previously unexpectedly conflict with and not take precedent over the button's own margins.
 
 ## 5.0.3
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,7 +10,6 @@ const gulpif = require('gulp-if');
 const sass = require('gulp-sass');
 const gulpStylelint = require('gulp-stylelint');
 const sourcemaps = require('gulp-sourcemaps');
-const uswds = require('uswds-gulp/config/uswds');
 const browserify = require('browserify');
 const babel = require('gulp-babel');
 const source = require('vinyl-source-stream');
@@ -124,7 +123,7 @@ gulp.task('build-sass', () => {
     .pipe(sourcemaps.init({ largeFile: true }))
     .pipe(
       sass({
-        includePaths: [PROJECT_SASS_SRC, `${uswds}/scss`, `${uswds}/scss/packages`],
+        includePaths: [PROJECT_SASS_SRC, 'node_modules'],
       }).on('error', notificationOptions.handler),
     )
     .pipe(postcss(plugins))
@@ -146,7 +145,6 @@ const underscorePrefix = () => gulpif((f) => f.basename[0] !== '_', rename({ pre
 gulp.task('copy-login-scss', () =>
   gulp
     .src([`${PROJECT_SASS_SRC}/**/*.scss`])
-    .pipe(replace("@import 'uswds'", "@import 'uswds/uswds'"))
     .pipe(replaceUrls())
     .pipe(underscorePrefix())
     .pipe(gulp.dest(SCSS_DEST)),
@@ -154,10 +152,10 @@ gulp.task('copy-login-scss', () =>
 
 gulp.task('copy-uswds-scss', () =>
   gulp
-    .src([`${uswds}/scss/**/*.scss`])
+    .src(['node_modules/uswds/dist/scss/**/*.scss'])
     .pipe(replaceUrls())
     .pipe(underscorePrefix())
-    .pipe(gulp.dest(`${SCSS_DEST}/uswds`)),
+    .pipe(gulp.dest(`${SCSS_DEST}/uswds/dist/scss`)),
 );
 
 gulp.task('copy-scss', gulp.parallel('copy-login-scss', 'copy-uswds-scss'));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -121,11 +121,7 @@ gulp.task('build-sass', () => {
     .src([`${PROJECT_SASS_SRC}/*.scss`])
     .pipe(replace(/\buswds @version\b/g, `uswds v${uswdsPkg.version}`))
     .pipe(sourcemaps.init({ largeFile: true }))
-    .pipe(
-      sass({
-        includePaths: [PROJECT_SASS_SRC, 'node_modules'],
-      }).on('error', notificationOptions.handler),
-    )
+    .pipe(sass().on('error', notificationOptions.handler))
     .pipe(postcss(plugins))
     .pipe(gulp.dest(CSS_DEST))
     .pipe(notify(notificationOptions.success));
@@ -155,7 +151,7 @@ gulp.task('copy-uswds-scss', () =>
     .src(['node_modules/uswds/dist/scss/**/*.scss'])
     .pipe(replaceUrls())
     .pipe(underscorePrefix())
-    .pipe(gulp.dest(`${SCSS_DEST}/uswds/dist/scss`)),
+    .pipe(gulp.dest(`${SCSS_DEST}/uswds`)),
 );
 
 gulp.task('copy-scss', gulp.parallel('copy-login-scss', 'copy-uswds-scss'));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -98,7 +98,7 @@ gulp.task('build-js', () => {
 gulp.task('watch-js', () => gulp.watch(`${PROJECT_JS_SRC}/**/*.js`, gulp.series('build-js')));
 
 gulp.task('lint-sass', () =>
-  gulp.src(`${PROJECT_SASS_SRC}/**/*.scss`).pipe(
+  gulp.src([`${PROJECT_SASS_SRC}/**/*.scss`, `!${PROJECT_SASS_SRC}/uswds/**/*.scss`]).pipe(
     gulpStylelint({
       failAfterError: true,
       reporters: [{ formatter: 'string', console: true }],

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -154,7 +154,7 @@ gulp.task('copy-uswds-scss', () =>
     .pipe(gulp.dest(`${SCSS_DEST}/uswds`)),
 );
 
-gulp.task('copy-scss', gulp.parallel('copy-login-scss', 'copy-uswds-scss'));
+gulp.task('copy-scss', gulp.series('copy-login-scss', 'copy-uswds-scss'));
 
 gulp.task('lint', gulp.parallel('lint-js', 'lint-sass'));
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19602,11 +19602,6 @@
         }
       }
     },
-    "uswds-gulp": {
-      "version": "github:uswds/uswds-gulp#5e32f1b99279a6e50ad875e66cc4cb77b456c390",
-      "from": "github:uswds/uswds-gulp",
-      "dev": true
-    },
     "util": {
       "version": "0.12.3",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.3.tgz",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
     "serve": "^11.3.2",
     "stylelint": "^13.7.2",
     "stylelint-scss": "^3.18.0",
-    "uswds-gulp": "github:uswds/uswds-gulp",
     "vinyl-buffer": "^1.0.1",
     "vinyl-source-stream": "^2.0.0",
     "wait-on": "^5.3.0",

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -8,7 +8,9 @@
 @import 'uswds-theme/utilities';
 @import 'uswds-theme/components';
 
-@import 'uswds';
+@import 'uswds/dist/scss/packages/required';
+@import 'uswds/dist/scss/packages/global';
+@import 'uswds/dist/scss/packages/uswds-components';
 
 @import 'functions/focus';
 
@@ -27,3 +29,5 @@
 @import 'components/spinner';
 @import 'components/typography';
 @import 'components/verification-badge';
+
+@import 'uswds/dist/scss/packages/uswds-utilities';

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -8,9 +8,9 @@
 @import 'uswds-theme/utilities';
 @import 'uswds-theme/components';
 
-@import 'uswds/dist/scss/packages/required';
-@import 'uswds/dist/scss/packages/global';
-@import 'uswds/dist/scss/packages/uswds-components';
+@import 'uswds/packages/required';
+@import 'uswds/packages/global';
+@import 'uswds/packages/uswds-components';
 
 @import 'functions/focus';
 
@@ -30,4 +30,4 @@
 @import 'components/typography';
 @import 'components/verification-badge';
 
-@import 'uswds/dist/scss/packages/uswds-utilities';
+@import 'uswds/packages/uswds-utilities';

--- a/src/scss/uswds
+++ b/src/scss/uswds
@@ -1,0 +1,1 @@
+../../node_modules/uswds/dist/scss


### PR DESCRIPTION
**Why**: To match USWDS intended load order of stylesheets, to allow utility classes to take precedence over component styles, and to facilitate a potential future use of [USWDS 2.11.0 package subsetting](https://designsystem.digital.gov/about/releases/#v2.10.0%20Beta%200-intermediate-package-subsetting).

USWDS [loads utility stylesheets after components](https://github.com/uswds/uswds/blob/develop/src/stylesheets/uswds.scss), allowing for those utility classes to apply usually as expected as an override to the component style selectors of equal specificity, as an alternative to resorting to [`$utilities-use-important`](https://github.com/uswds/uswds/blob/1908d1391bc59410624ca1934cc70b7404e8f443/src/stylesheets/theme/_uswds-theme-utilities.scss#L20).

Previously, we imported all USWDS styles prior to loading our own component overrides. Thus, the component overrides could take precedence over the utility classes. For example, it was not possible to use [margin utility classes](https://designsystem.digital.gov/utilities/margin-and-padding/) with the [unstyled button](https://design.login.gov/components/buttons/#unstyled) (observed in https://github.com/18F/identity-idp/pull/4869). 

Note that depending on the selector used for a component's styles, a utility class may still "lose" to a component's own styles. If this proves to be problematic (or is argued to be problematic now), it may be worth reevaluating to consider using the `$utilities-use-important` theme setting value, which applies [`!important`](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity#the_!important_exception) to all utility classes.