### PR TITLE
Fix search input square corners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Reduce the border width of the normal outline button to the intended width of `1px` (previously `2px`). The big variant of the outline button is unaffected by this change, and remains `2px`.
 - Fix rounded corners on sidebar current page item.
+- Fix unintentional rounded corners on search text field.
 
 ## 5.0.3
 

--- a/src/scss/components/_inputs.scss
+++ b/src/scss/components/_inputs.scss
@@ -30,6 +30,7 @@ $border-width: 1px;
 .usa-search__input {
   // Restore USWDS inherited square corners customized for `.usa-input`.
   border-bottom-right-radius: 0;
+  border-right: none;
   border-top-right-radius: 0;
 }
 

--- a/src/scss/components/_inputs.scss
+++ b/src/scss/components/_inputs.scss
@@ -26,6 +26,13 @@ $border-width: 1px;
   }
 }
 
+[type='search'],
+.usa-search__input {
+  // Restore USWDS inherited square corners customized for `.usa-input`.
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+
 .usa-select {
   @include u-border($border-width, 'primary-light');
   @include add-background-svg('arrow-down-filled');


### PR DESCRIPTION
See discussion: https://github.com/18F/identity-dashboard/pull/420#discussion_r615840215

**Why**: Search input corners are intended to be squared in USWDS, but it is being overridden unintentionally by our `.usa-input` border radius customizations.

- Border
  - Original: https://github.com/uswds/uswds/blob/0f1f4d0/src/stylesheets/components/_search.scss#L83
  - Customized: https://github.com/18F/identity-style-guide/blob/ba2b1f7/src/scss/components/_inputs.scss#L7
- Border radius
  - Original: https://github.com/uswds/uswds/blob/0f1f4d0/src/stylesheets/components/_search.scss#L82-L84
  - Customized: https://github.com/18F/identity-style-guide/blob/ba2b1f7/src/scss/components/_inputs.scss#L10

**Live preview:** https://federalist-2f194a10-945e-4413-be01-46ca6dae5358.app.cloud.gov/preview/18f/identity-style-guide/aduth-search-square-corners/components/search/

Before|After
---|---
![image](https://user-images.githubusercontent.com/1779930/115461614-9db7e200-a1f7-11eb-896f-4452bbb6fd15.png)|![image](https://user-images.githubusercontent.com/1779930/115461532-87aa2180-a1f7-11eb-8a8d-3ce423c47743.png)