### PR TITLE
Add package entrypoints for granular stylesheet loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### New Features
+
+- Add support for SASS package entrypoints to limit or control loading of styles, [similar to USWDS components](https://designsystem.digital.gov/components/packages/). Available packages are `packages/required`, `packages/global`, `packages/components`, `packages/utilities-required`, and `packages/utilities` (includes `packages/utilities-required`).
+
 ### Bug Fixes
 
 - Reduce the border width of the normal outline button to the intended width of `1px` (previously `2px`). The big variant of the outline button is unaffected by this change, and remains `2px`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### New Features
 
-- Add support for SASS package entrypoints to limit or control loading of styles, [similar to USWDS components](https://designsystem.digital.gov/components/packages/). Available packages are `packages/required`, `packages/global`, `packages/components`, `packages/utilities-required`, and `packages/utilities` (includes `packages/utilities-required`).
+- Add support for SASS package entrypoints to limit or control loading of styles, [similar to USWDS components](https://designsystem.digital.gov/components/packages/). Available packages are `packages/required`, `packages/global`, `packages/components`, and `packages/utilities`.
 
 ### Bug Fixes
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -75,6 +75,17 @@ Use the original source scss files if your project will be extending styles â€”Â
 @import 'node_modules/identity-style-guide/dist/assets/scss/styles';
 ```
 
+If you only want to include specific parts of the design system, or if you need more fine-grained control over the load order of style sheets, you can import the individual package groupings. This can be useful if your application defines its own custom components, as you may want to load utility classes after your component stylesheets to avoid style priority conflicts.
+
+```scss
+@import 'node_modules/identity-style-guide/dist/assets/scss/packages/required';
+@import 'node_modules/identity-style-guide/dist/assets/scss/packages/global';
+@import 'node_modules/identity-style-guide/dist/assets/scss/packages/components';
+// ... load own components' styles
+@import 'node_modules/identity-style-guide/dist/assets/scss/packages/utilities';
+```
+
+
 ### Use with Rails
 
 The scss files natively support `asset-path()` out-of-the-box for ease of use with the Rails Asset Pipeline. To use with Rails, configure Rails to look for assets in both `node_modules` and the identity-style-guide module:

--- a/src/scss/packages/_components.scss
+++ b/src/scss/packages/_components.scss
@@ -1,0 +1,17 @@
+@import '../uswds/packages/uswds-components';
+
+@import '../components/accordions';
+@import '../components/alerts';
+@import '../components/banner';
+@import '../components/buttons';
+@import '../components/cards';
+@import '../components/code';
+@import '../components/footer';
+@import '../components/general';
+@import '../components/hero';
+@import '../components/inputs';
+@import '../components/navbar';
+@import '../components/sidenav';
+@import '../components/spinner';
+@import '../components/typography';
+@import '../components/verification-badge';

--- a/src/scss/packages/_global.scss
+++ b/src/scss/packages/_global.scss
@@ -1,0 +1,1 @@
+@import '../uswds/packages/global';

--- a/src/scss/packages/_required.scss
+++ b/src/scss/packages/_required.scss
@@ -10,3 +10,6 @@
 
 @import '../functions/asset-path';
 @import '../functions/focus';
+
+@import '../uswds/utilities/palettes/all';
+@import '../uswds/utilities/rules/all';

--- a/src/scss/packages/_required.scss
+++ b/src/scss/packages/_required.scss
@@ -1,0 +1,12 @@
+@import '../uswds-theme/custom-styles';
+@import '../uswds-theme/general';
+@import '../uswds-theme/typography';
+@import '../uswds-theme/spacing';
+@import '../uswds-theme/color';
+@import '../uswds-theme/utilities';
+@import '../uswds-theme/components';
+
+@import '../uswds/packages/required';
+
+@import '../functions/asset-path';
+@import '../functions/focus';

--- a/src/scss/packages/_utilities-required.scss
+++ b/src/scss/packages/_utilities-required.scss
@@ -1,0 +1,3 @@
+@import '../uswds/utilities/utility-fonts';
+@import '../uswds/utilities/palettes/all';
+@import '../uswds/utilities/rules/all';

--- a/src/scss/packages/_utilities-required.scss
+++ b/src/scss/packages/_utilities-required.scss
@@ -1,3 +1,0 @@
-@import '../uswds/utilities/utility-fonts';
-@import '../uswds/utilities/palettes/all';
-@import '../uswds/utilities/rules/all';

--- a/src/scss/packages/_utilities.scss
+++ b/src/scss/packages/_utilities.scss
@@ -1,0 +1,3 @@
+@import 'utilities-required';
+@import '../uswds/utilities/rules/package';
+@include render-utilities-in($utilities-package);

--- a/src/scss/packages/_utilities.scss
+++ b/src/scss/packages/_utilities.scss
@@ -1,3 +1,3 @@
-@import 'utilities-required';
+@import '../uswds/utilities/utility-fonts';
 @import '../uswds/utilities/rules/package';
 @include render-utilities-in($utilities-package);

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -1,33 +1,4 @@
-@import 'functions/asset-path';
-
-@import 'uswds-theme/custom-styles';
-@import 'uswds-theme/general';
-@import 'uswds-theme/typography';
-@import 'uswds-theme/spacing';
-@import 'uswds-theme/color';
-@import 'uswds-theme/utilities';
-@import 'uswds-theme/components';
-
-@import 'uswds/packages/required';
-@import 'uswds/packages/global';
-@import 'uswds/packages/uswds-components';
-
-@import 'functions/focus';
-
-@import 'components/accordions';
-@import 'components/alerts';
-@import 'components/banner';
-@import 'components/buttons';
-@import 'components/cards';
-@import 'components/code';
-@import 'components/footer';
-@import 'components/general';
-@import 'components/hero';
-@import 'components/inputs';
-@import 'components/navbar';
-@import 'components/sidenav';
-@import 'components/spinner';
-@import 'components/typography';
-@import 'components/verification-badge';
-
-@import 'uswds/packages/uswds-utilities';
+@import 'packages/required';
+@import 'packages/global';
+@import 'packages/components';
+@import 'packages/utilities';


### PR DESCRIPTION
**Why**: To limit or control the loading of styles.

Use-cases:

1. Avoid specificity conflicts between utility classes and a consuming project's custom components
2. Load only required mixins and functions to support CSS code splitting

This also mirrors USWDS packages, with two main differences:

- Simplifies naming of `uswds-components` and `uswds-utilities` to just `components` and `utilities`
- Extracts `utilities-required` from `utilities` to allow non-rendering import of utility mixins.

See:

- https://designsystem.digital.gov/components/packages/
- https://github.com/uswds/uswds/blob/develop/src/stylesheets/uswds.scss

Next steps:

Per the above use-cases, this is useful for `identity-idp` and the following diff would help toward resolving existing specificity conflicts and simplify code splitting usage:

```diff
diff --git a/app/assets/stylesheets/application.css.scss b/app/assets/stylesheets/application.css.scss
index 8576adb31..9a5ab78d6 100644
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -1,6 +1,9 @@
 @import 'variables/colors';
 @import 'variables/app';
 @import 'vendor';
-@import 'identity-style-guide/dist/assets/scss/styles';
+@import 'identity-style-guide/dist/assets/scss/packages/required';
+@import 'identity-style-guide/dist/assets/scss/packages/global';
+@import 'identity-style-guide/dist/assets/scss/packages/components';
 @import 'components/all';
 @import 'print';
+@import 'identity-style-guide/dist/assets/scss/packages/utilities';
diff --git a/config/webpack/environment.js b/config/webpack/environment.js
index c55bb013f..65fd2682b 100644
--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -25,19 +25,8 @@ const sassLoader = environment.loaders.get('sass');
 sassLoader.use.find(({ loader }) => loader === 'sass-loader').options.additionalData = `
 $font-path: '~identity-style-guide/dist/assets/fonts';
 $image-path: '~identity-style-guide/dist/assets/img';
-@import '~identity-style-guide/dist/assets/scss/functions/asset-path';
-@import '~identity-style-guide/dist/assets/scss/functions/focus';
-@import '~identity-style-guide/dist/assets/scss/uswds-theme/custom-styles';
-@import '~identity-style-guide/dist/assets/scss/uswds-theme/general';
-@import '~identity-style-guide/dist/assets/scss/uswds-theme/typography';
-@import '~identity-style-guide/dist/assets/scss/uswds-theme/spacing';
-@import '~identity-style-guide/dist/assets/scss/uswds-theme/color';
-@import '~identity-style-guide/dist/assets/scss/uswds-theme/utilities';
-@import '~identity-style-guide/dist/assets/scss/uswds-theme/components';
-@import '~identity-style-guide/dist/assets/scss/uswds/packages/required';
-@import '~identity-style-guide/dist/assets/scss/uswds/utilities/palettes/all';
-@import '~identity-style-guide/dist/assets/scss/uswds/utilities/rules/all';
-@import '~identity-style-guide/dist/assets/scss/uswds/utilities/rules/package';`;
+@import '~identity-style-guide/dist/assets/scss/packages/required';
+@import '~identity-style-guide/dist/assets/scss/packages/utilities-required';`;
 
 sassLoader.use.find(({ loader }) => loader === 'css-loader').options.sourceMap = false;
```

Example conflicts:

- https://github.com/18F/identity-idp/blob/0a81dd7/app/assets/stylesheets/components/_btn.scss#L38
- https://github.com/18F/identity-idp/blob/0a81dd7/app/views/idv/shared/_error.html.erb#L40
   - Should use `margin-top-5` but currently conflicts with custom component's [own margins](https://github.com/18F/identity-idp/blob/0a81dd7441038ae7992d6923b7b73138ab91272f/app/assets/stylesheets/components/_troubleshooting-options.scss#L2)