### PR TITLE
Bump Jest timeout for SCSS compilation tests

### DIFF
--- a/test/dist/scss.test.js
+++ b/test/dist/scss.test.js
@@ -9,7 +9,7 @@ test('scss files can be imported without node_modules', async () => {
   });
 
   expect(results.css.toString('utf-8')).toMatch(/\.usa-/);
-});
+}, 10000);
 
 test('if an asset-path function is defined, it is used to generate asset paths with $image-path and $font-path', async () => {
   const results = await util.promisify(compiler.render)({
@@ -37,4 +37,4 @@ test('if an asset-path function is defined, it is used to generate asset paths w
   expect(usaAlertWarning).toMatch(/test-path-rewritten\/test-img/);
   expect(usaInputError).toMatch(/test-path-rewritten\/test-img/);
   expect(fontFace).toMatch(/test-path-rewritten\/test-fonts/);
-});
+}, 10000);


### PR DESCRIPTION
**Why**: So that the build doesn't fail by exceeding the default timeout of 5 seconds, where allowing the compilation to complete would otherwise succeed.

We should revisit the fact that this test is as slow as it is in the first place, possibly:

- Replacing `gulp-sass` compiler (using `node-sass` under the hood) with Dart-based SASS ([benchmarks](https://github.com/sass/dart-sass/blob/master/perf.md), e.g. currently-experimental [`sass-embedded`](https://www.npmjs.com/package/sass-embedded))
- Combining tests
- Limiting what we need to import to verify the expected behavior (vs. entire USWDS)