### PR TITLE
Fix mobile primary navigation styles

### DIFF
--- a/src/img/close-primary.svg
+++ b/src/img/close-primary.svg
@@ -1,3 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 15 15">
-  <path fill="none" stroke="#0071bb" stroke-linecap="round" stroke-width="2" d="M0 13.0332964L13.0332964 0M13.0332964 13.0332964L0 0" transform="translate(1 1)"/>
-</svg>
+<svg width="15" height="15" viewBox="0 0 15 15" xmlns="http://www.w3.org/2000/svg"><path fill="none" stroke="#0071bb" stroke-linecap="round" stroke-width="2" d="M1 14.033L14.033 1m0 13.033L1 1"/></svg>

--- a/src/img/close.svg
+++ b/src/img/close.svg
@@ -1,0 +1,1 @@
+<svg width="15" height="15" viewBox="0 0 15 15" xmlns="http://www.w3.org/2000/svg"><path fill="none" stroke="#454545" stroke-linecap="round" stroke-width="2" d="M1 14.033L14.033 1m0 13.033L1 1"/></svg>

--- a/src/scss/components/_navbar.scss
+++ b/src/scss/components/_navbar.scss
@@ -95,6 +95,13 @@ $header-height: 10;
         color: color('ink');
       }
     }
+
+    .usa-nav__primary-item {
+      > a,
+      > .usa-nav__link {
+        @include u-padding-y(2);
+      }
+    }
   }
 
   @include at-media($theme-header-min-width) {
@@ -120,10 +127,6 @@ $header-height: 10;
       .usa-current {
         @include add-bar(0.5, 'secondary', 'bottom', 0, 1.5, 0);
         font-weight: font-weight('bold');
-
-        &:hover {
-          color: color('primary-dark');
-        }
       }
     }
 
@@ -281,12 +284,15 @@ $header-height: 10;
   }
 }
 
-// Navigation menu
+// Navigation close button
 // ---------------------------------
 
-.usa-menu__btn {
-  height: units($header-height);
+.usa-nav__close img {
+  width: units(1.5);
 }
+
+// Navigation menu
+// ---------------------------------
 
 .usa-logo__img {
   @include at-media-max($theme-header-min-width) {

--- a/src/scss/components/_sidenav.scss
+++ b/src/scss/components/_sidenav.scss
@@ -27,8 +27,6 @@
 
 .usa-sidenav__sublist a:not(.usa-button) {
   padding-left: units(4);
-  padding-top: units(1.5);
-  padding-bottom: units(1.5);
 }
 
 .usa-sidenav__sublist .usa-current {


### PR DESCRIPTION
**Why**: The USWDS upgrade in #219 changed default padding for most navigation menus. This was corrected in the side navigation, but mobile primary navigation still appeared more condensed than previously. Additionally, default scaling for the navigation close button was changed in USWDS to be much larger due to a change to use the new icon set, causing the icon to appear very large. The design system was not using our custom version of the icon anyways. This has been corrected.

Before|After
---|---
![image](https://user-images.githubusercontent.com/1779930/122227741-2b751e00-ce85-11eb-9b0f-f2ea20c776c7.png)|![image](https://user-images.githubusercontent.com/1779930/122227775-32039580-ce85-11eb-8d09-44c9d04ef39c.png)

Open questions:

- _Is this what we want the menu to look like?_ I couldn't find a canonical reference for what the mobile menu should look like. The adjustments here are a best compromise of restoring previous expectations. This could be a good opportunity to make updates if we wanted.
- _Do we want to use the USWDS icon?_ Expanding on the above note about USWDS transitioning to new icon set for the mobile "Close" button, it could help simplify our overrides if we use the USWDS icon. That said, while it is very similar in appearance to our custom icon, it's not exactly the same; specifically, there's a slight rounding to the linecaps in our version.
   - [USWDS "Close"](https://raw.githubusercontent.com/uswds/uswds/develop/src/img/usa-icons/close.svg)
   - [Login.gov "Close"](https://raw.githubusercontent.com/18F/identity-style-guide/9ebc78f52ea932c315d3102d6bbbbb0edefb4052/src/img/close.svg)