### PR TITLE
Update capitalization guidance in content guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,7 +99,7 @@
 ### Breaking Changes
 
 - Updates USWDS from 2.0.3 to 2.9.0. Review [release notes](https://designsystem.digital.gov/about/releases/) for specific changes which may apply. Specific impactful changes include...
-  - The Tooltip component is now inherited from USWDS, newly introduced as of USWDS 2.8.0. [See component documentation](https://designsystem.digital.gov/components/tooltip/) for more information. The markup of this component is significantly different than that of the component previously implemented in the login.gov Design System.
+  - The Tooltip component is now inherited from USWDS, newly introduced as of USWDS 2.8.0. [See component documentation](https://designsystem.digital.gov/components/tooltip/) for more information. The markup of this component is significantly different than that of the component previously implemented in the Login.gov Design System.
   - Due to a rounding precision fix, line-heights for text may appear larger than it had previously.
   - Guidance for many components has been updated to improve accessibility and usability of markup. Neglecting to update this markup should not result in user-facing regressions, but you are recommended to update to improve end-user experience. Refer to the release notes and related component documentation for specifics:
     - SVG images should include `role="img"`.

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 title: Login.gov Design System
-description: A place for designers and developers to see components available for use on login.gov sites.
+description: A place for designers and developers to see components available for use on Login.gov sites.
 github_repo_url: https://github.com/18F/identity-style-guide
 url: https://federalist-proxy.app.cloud.gov/site/18f/identity-style-guide
 

--- a/docs/_components/code-formatting.md
+++ b/docs/_components/code-formatting.md
@@ -1,7 +1,7 @@
 ---
 title: Code formatting
 lead: >
-  Highlight code samples using the login.gov color palette.
+  Highlight code samples using the Login.gov color palette.
 ---
 
 Any pygments-compatible syntax highlighter will produce markup that is compatible with the code highlighting classes included.

--- a/docs/_components/search.md
+++ b/docs/_components/search.md
@@ -15,7 +15,7 @@ Search should be easily found. For the default search version, consider displayi
 {% capture example %}
 <form accept-charset="UTF-8" action="https://search.usa.gov/search" class="usa-search usa-search--smalldisplay-flex flex-justify-center tablet:grid-col-4" method="get" role="search">
   <input name="utf8" type="hidden" value="&#x2713;"/>
-  <input name="affiliate" type="hidden" value="Login.gov"/>
+  <input name="affiliate" type="hidden" value="login.gov"/>
   <label class="usa-sr-only" for="search-field-header-nav">Search</label>
   <input class="usa-input" id="search-field-header-nav" name="query" type="search">
   <button class="usa-button" type="submit">

--- a/docs/_components/search.md
+++ b/docs/_components/search.md
@@ -10,12 +10,12 @@ lead: >
 ---
 
 ## Default
-Search should be easily found. For the default search version, consider displaying in the header and/or side navigation. 
+Search should be easily found. For the default search version, consider displaying in the header and/or side navigation.
 
 {% capture example %}
 <form accept-charset="UTF-8" action="https://search.usa.gov/search" class="usa-search usa-search--smalldisplay-flex flex-justify-center tablet:grid-col-4" method="get" role="search">
   <input name="utf8" type="hidden" value="&#x2713;"/>
-  <input name="affiliate" type="hidden" value="login.gov"/>
+  <input name="affiliate" type="hidden" value="Login.gov"/>
   <label class="usa-sr-only" for="search-field-header-nav">Search</label>
   <input class="usa-input" id="search-field-header-nav" name="query" type="search">
   <button class="usa-button" type="submit">
@@ -31,7 +31,7 @@ If searching is a primary action of the site, consider adding the big variant ve
 {% capture example %}
 <form accept-charset="UTF-8" action="https://search.usa.gov/search" class="usa-search usa-search--big display-flex flex-justify-center" method="get" role="search">
   <input name="utf8" type="hidden" value="&#x2713;"/>
-  <input name="affiliate" type="hidden" value="login.gov"/>
+  <input name="affiliate" type="hidden" value="Login.gov"/>
   <label class="usa-sr-only" for="search-field-{{ include.id }}">Search</label>
   <input class="usa-input" id="search-field-{{ include.id }}" name="query" type="search">
   <button class="usa-button" type="submit">

--- a/docs/_components/search.md
+++ b/docs/_components/search.md
@@ -31,7 +31,7 @@ If searching is a primary action of the site, consider adding the big variant ve
 {% capture example %}
 <form accept-charset="UTF-8" action="https://search.usa.gov/search" class="usa-search usa-search--big display-flex flex-justify-center" method="get" role="search">
   <input name="utf8" type="hidden" value="&#x2713;"/>
-  <input name="affiliate" type="hidden" value="Login.gov"/>
+  <input name="affiliate" type="hidden" value="login.gov"/>
   <label class="usa-sr-only" for="search-field-{{ include.id }}">Search</label>
   <input class="usa-input" id="search-field-{{ include.id }}" name="query" type="search">
   <button class="usa-button" type="submit">

--- a/docs/_includes/helpers/base-component.html
+++ b/docs/_includes/helpers/base-component.html
@@ -7,5 +7,5 @@
 </a>
 
 <a href="{{ sass_url }}" class="usa-link usa-link--external">
-  View login.gov SCSS on GitHub
+  View Login.gov SCSS on GitHub
 </a>

--- a/docs/_includes/navbar.html
+++ b/docs/_includes/navbar.html
@@ -4,7 +4,7 @@
   <div class="usa-navbar">
     <div class="usa-logo" id="basic-logo">
       <a href="{{ site.baseurl }}/" title="Home" aria-label="Home">
-        <img src="{{ site.baseurl }}/assets/img/login-gov-logo.svg" role="img" class="usa-logo__img" alt="login.gov">
+        <img src="{{ site.baseurl }}/assets/img/login-gov-logo.svg" role="img" class="usa-logo__img" alt="Login.gov">
         <em class="usa-logo__text">Design System</em>
       </a>
     </div>

--- a/docs/brand.md
+++ b/docs/brand.md
@@ -9,32 +9,32 @@ sidenav:
   - text: Tagline
     href: "#tagline"
 lead: >
-  When working with the login.gov brand, follow these guidelines to ensure you're representing the product in a consistent way across all mediums.
+  When working with the Login.gov brand, follow these guidelines to ensure you're representing the product in a consistent way across all mediums.
 ---
 
 ## Logo
 
-Consistent and repeated use of the logo and lockups will establish equity and strengthen the visual identity of login.gov. To ensure consistency, it is critical that every person who uses the logo does so in accordance with the guidelines that follow, regardless of personal preference.
+Consistent and repeated use of the logo and lockups will establish equity and strengthen the visual identity of Login.gov. To ensure consistency, it is critical that every person who uses the logo does so in accordance with the guidelines that follow, regardless of personal preference.
 
 ### The shield and wordmark
 
-The login.gov logo is the cornerstone of our brand. Whenever possible, the red and blue version should be used. A white (or reverse) version can be used on a dark background.
+The Login.gov logo is the cornerstone of our brand. Whenever possible, the red and blue version should be used. A white (or reverse) version can be used on a dark background.
 
-<a href="{{ site.baseurl }}/assets/img/login-gov-logo.svg" download><img src="{{ site.baseurl }}/assets/img/login-gov-logo.svg" role="img" alt="login.gov logo" class="padding-4"></a>
+<a href="{{ site.baseurl }}/assets/img/login-gov-logo.svg" download><img src="{{ site.baseurl }}/assets/img/login-gov-logo.svg" role="img" alt="Login.gov logo" class="padding-4"></a>
 
-<a href="{{ site.baseurl }}/assets/img/login-gov-logo-rev.svg" download><img src="{{ site.baseurl }}/assets/img/login-gov-logo-rev.svg" role="img" alt="login.gov logo" class="bg-primary-darker padding-4"></a>
+<a href="{{ site.baseurl }}/assets/img/login-gov-logo-rev.svg" download><img src="{{ site.baseurl }}/assets/img/login-gov-logo-rev.svg" role="img" alt="Login.gov logo" class="bg-primary-darker padding-4"></a>
 
 ### Whitespace
 
 The logo should always be surrounded by generous white space. The diagram below defines the minimum amount of clear space needed, which is based on the cap-height of the typography.
 
-<img src="{{ site.baseurl }}/assets/img/style-guide/login-gov-logo-spacing.svg" role="img" alt="login.gov logo spacing diagram">
+<img src="{{ site.baseurl }}/assets/img/style-guide/login-gov-logo-spacing.svg" role="img" alt="Login.gov logo spacing diagram">
 
 ### Minimum size
 
 Establishing a minimum size ensures that the impact and legibility of the logo is not compromised in application.
 
-<img src="{{ site.baseurl }}/assets/img/style-guide/login-gov-logo-minimum-size.svg" role="img" alt="login.gov logo minimum size diagram">
+<img src="{{ site.baseurl }}/assets/img/style-guide/login-gov-logo-minimum-size.svg" role="img" alt="Login.gov logo minimum size diagram">
 
 ## Logo Usage
 
@@ -42,60 +42,60 @@ Establishing a minimum size ensures that the impact and legibility of the logo i
 
 For optimum legibility and brand consistency, the logo should never be used in white with a light background. Conversely, the standard logo should never appear on a dark background.
 
-<img src="{{ site.baseurl }}/assets/img/login-gov-logo-rev.svg" role="img" alt="login.gov logo" class="bg-primary-lighter padding-4">
+<img src="{{ site.baseurl }}/assets/img/login-gov-logo-rev.svg" role="img" alt="Login.gov logo" class="bg-primary-lighter padding-4">
 
-<img src="{{ site.baseurl }}/assets/img/login-gov-logo.svg" role="img" alt="login.gov logo" class="bg-gray-70 padding-4">
+<img src="{{ site.baseurl }}/assets/img/login-gov-logo.svg" role="img" alt="Login.gov logo" class="bg-gray-70 padding-4">
 
 ### Do not modify the logo
 
 <div class="grid-row grid-gap">
   <div class="tablet:grid-col-4">
     Do not outline.
-    <img src="{{ site.baseurl }}/assets/img/style-guide/login-gov-logo-outlined.svg" role="img" alt="login.gov logo outlined" class="display-block margin-top-1 margin-bottom-4">
+    <img src="{{ site.baseurl }}/assets/img/style-guide/login-gov-logo-outlined.svg" role="img" alt="Login.gov logo outlined" class="display-block margin-top-1 margin-bottom-4">
   </div>
   <div class="tablet:grid-col-4">
     Do not skew.
-    <img src="{{ site.baseurl }}/assets/img/style-guide/login-gov-logo-skewed.svg" role="img" alt="login.gov logo skewed" class="display-block margin-top-1 margin-bottom-4">
+    <img src="{{ site.baseurl }}/assets/img/style-guide/login-gov-logo-skewed.svg" role="img" alt="Login.gov logo skewed" class="display-block margin-top-1 margin-bottom-4">
   </div>
   <div class="tablet:grid-col-4">
     Do not apply effects.
-    <img src="{{ site.baseurl }}/assets/img/style-guide/login-gov-logo-with-effects.svg" role="img" alt="login.gov logo with effects" class="display-block margin-top-1 margin-bottom-4">
+    <img src="{{ site.baseurl }}/assets/img/style-guide/login-gov-logo-with-effects.svg" role="img" alt="Login.gov logo with effects" class="display-block margin-top-1 margin-bottom-4">
   </div>
   <div class="tablet:grid-col-4">
     Do not adjust spacing.
-    <img src="{{ site.baseurl }}/assets/img/style-guide/login-gov-logo-spaced.svg" role="img" alt="login.gov logo spaced" class="display-block margin-top-1 margin-bottom-4">
+    <img src="{{ site.baseurl }}/assets/img/style-guide/login-gov-logo-spaced.svg" role="img" alt="Login.gov logo spaced" class="display-block margin-top-1 margin-bottom-4">
   </div>
   <div class="tablet:grid-col-4">
     Do not apply drop shadows.
-    <img src="{{ site.baseurl }}/assets/img/style-guide/login-gov-logo-shadowed.svg" role="img" alt="login.gov logo shadowed" class="display-block margin-top-1 margin-bottom-4">
+    <img src="{{ site.baseurl }}/assets/img/style-guide/login-gov-logo-shadowed.svg" role="img" alt="Login.gov logo shadowed" class="display-block margin-top-1 margin-bottom-4">
   </div>
   <div class="tablet:grid-col-4">
     Do not distort.
-    <img src="{{ site.baseurl }}/assets/img/style-guide/login-gov-logo-distorted.svg" role="img" alt="login.gov logo distorted" class="display-block margin-top-1 margin-bottom-4">
+    <img src="{{ site.baseurl }}/assets/img/style-guide/login-gov-logo-distorted.svg" role="img" alt="Login.gov logo distorted" class="display-block margin-top-1 margin-bottom-4">
   </div>
   <div class="tablet:grid-col-4">
     Do not apply brand colors.
-    <img src="{{ site.baseurl }}/assets/img/style-guide/login-gov-logo-brand-colored.svg" role="img" alt="login.gov logo brand colored" class="display-block margin-top-1 margin-bottom-4">
+    <img src="{{ site.baseurl }}/assets/img/style-guide/login-gov-logo-brand-colored.svg" role="img" alt="Login.gov logo brand colored" class="display-block margin-top-1 margin-bottom-4">
   </div>
   <div class="tablet:grid-col-4">
     Do not apply gradients.
-    <img src="{{ site.baseurl }}/assets/img/style-guide/login-gov-logo-gradiented.svg" role="img" alt="login.gov logo gradiented" class="display-block margin-top-1 margin-bottom-4">
+    <img src="{{ site.baseurl }}/assets/img/style-guide/login-gov-logo-gradiented.svg" role="img" alt="Login.gov logo gradiented" class="display-block margin-top-1 margin-bottom-4">
   </div>
   <div class="tablet:grid-col-4">
     Do not rotate.
-    <img src="{{ site.baseurl }}/assets/img/style-guide/login-gov-logo-rotated.svg" role="img" alt="login.gov logo rotated" class="display-block margin-top-1 margin-bottom-4">
+    <img src="{{ site.baseurl }}/assets/img/style-guide/login-gov-logo-rotated.svg" role="img" alt="Login.gov logo rotated" class="display-block margin-top-1 margin-bottom-4">
   </div>
   <div class="tablet:grid-col-4">
     Do not mask images or graphics.
-    <img src="{{ site.baseurl }}/assets/img/style-guide/login-gov-logo-masked.svg" role="img" alt="login.gov logo masked" class="display-block margin-top-1 margin-bottom-4">
+    <img src="{{ site.baseurl }}/assets/img/style-guide/login-gov-logo-masked.svg" role="img" alt="Login.gov logo masked" class="display-block margin-top-1 margin-bottom-4">
   </div>
   <div class="tablet:grid-col-4">
     Do not use additional colors.
-    <img src="{{ site.baseurl }}/assets/img/style-guide/login-gov-logo-colored.svg" role="img" alt="login.gov logo colored" class="display-block margin-top-1 margin-bottom-4">
+    <img src="{{ site.baseurl }}/assets/img/style-guide/login-gov-logo-colored.svg" role="img" alt="Login.gov logo colored" class="display-block margin-top-1 margin-bottom-4">
   </div>
   <div class="tablet:grid-col-4">
     Do not separate the shield from the wordmark.
-    <img src="{{ site.baseurl }}/assets/img/style-guide/login-gov-shield.svg" role="img" alt="login.gov logo separated" class="display-block margin-top-1 margin-bottom-4">
+    <img src="{{ site.baseurl }}/assets/img/style-guide/login-gov-shield.svg" role="img" alt="Login.gov logo separated" class="display-block margin-top-1 margin-bottom-4">
   </div>
 </div>
 

--- a/docs/color.md
+++ b/docs/color.md
@@ -2,7 +2,7 @@
 permalink: /color/
 title: Color
 lead: >
-  These official colors connect the login.gov brand across products — use them when possible.
+  These official colors connect the Login.gov brand across products — use them when possible.
 ---
 
 The color codes listed beneath each name indicate what names can be used with the U.S. Web Design System’s color utility classes. For example:

--- a/docs/content.md
+++ b/docs/content.md
@@ -14,7 +14,7 @@ sidenav:
     href: "#translations"
 
 lead: >
-  This guide is intended to help login.gov team members create content that is consistent and accessible to our users.
+  This guide is intended to help Login.gov team members create content that is consistent and accessible to our users.
 ---
 
 We follow the [18F content guide](https://content-guide.18f.gov/) and [federal plain language guidelines](https://www.plainlanguage.gov/guidelines/). This guide is intended as a supplement to those guides.
@@ -64,11 +64,10 @@ Login.gov’s voice is&hellip;
 
 |Correct term or phrase   	|Common errors   	|More information   	|
 |---	|---	|---	|
-|login.gov   	|Login; Login.gov; LOGIN.gov; LOGIN   	|Use all lowercase and include the “.gov”. When at the beginning of a sentence, capitalize the first L.   	|
 |Online identity proofing, prove your identity   	|Identity verification, verify your identity,   	|   	|
 |two-factor authentication (2FA)   	|multi-factor authentication (MFA)   	|Always write out on first use   	|
 |authentication method   	|authentication device; secondary authentication devise; authentication factor; two-factor authenticator; security option; security method; security factor   	|   	|
-|sign in; sign in to   	|log in; sign into; log into   	|For better readability and visual differentiation from login.gov   	|
+|sign in; sign in to   	|log in; sign into; log into   	|For better readability and visual differentiation from Login.gov   	|
 |Must; have to   	|should   	|Do not use “should” when it is a required action   	|
 |can   	|may   	|“Can” add clarity   	|
 |Identity verification; verifying your identity   	|Proofing your identity, IAL2   	|IAL2 is only used internally and when communicating with partners who are looking for NIST standards. Never use IAL2 when communicating with users in the app. It’s acceptable to explain with “prove you are who you say you are”   	|
@@ -78,14 +77,14 @@ Login.gov’s voice is&hellip;
 |AM or PM   	|am/pm, a.m./p.m., A.M./P.M., military time   	|   	|
 |Add   	|Enable   	|   	|
 |Delete   	|Disable, Remove   	|For permanent removal   	|
-|Login.gov account   	|Login.gov profile  	|Example: You sign in to your login.gov account to see your USAJOBS profile   	|
+|Login.gov account   	|Login.gov profile  	|Example: You sign in to your Login.gov account to see your USAJOBS profile   	|
 |   	|Encrypt   	|Avoid using “encrypt” in the UI. If needed, do not use it as a call to action and use explanatory text   	|
 |Government application   	|SP   	|When referring to SPs in general terms. When, possible name the specific SP in the UI.   	|
 |Security code   	|one-time password (OTP)   	|The code users receive by phone or authentication app. OTP is for internal use only.   	|
 
 ## Translations
 
-In addition to English, we translate content into French and Spanish. Write content that is straightforward, active voice, 
+In addition to English, we translate content into French and Spanish. Write content that is straightforward, active voice,
 
 **Resource:**
 

--- a/docs/images.md
+++ b/docs/images.md
@@ -1,7 +1,7 @@
 ---
 permalink: /images/
 title: Images
-lead: This guidance is intended to help you use images effectively in login.gov products.
+lead: This guidance is intended to help you use images effectively in Login.gov products.
 redirect_from: /accessibility/policies/
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ lead: >
           The key to a strong brand <br>is <span class="text-accent-cool">consistency</span>.
         </div>
         <p class="usa-intro">{{ page.lead }}</p>
-        <a href="https://github.com/18F/identity-style-guide#configuring-for-development" class="usa-button usa-button--big">See install instructions on GitHub</a>
+        <a href="https://github.com/18F/identity-style-guide#configuring-for-development" class="usa-button usa-button--big">See installation instructions on GitHub</a>
       </div>
     </div>
   </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ permalink: /
 layout: home
 title: Overview
 lead: >
-  Use the login.gov Design System when developing login.gov sites to consistently identify the login.gov brand.
+  Use the Login.gov Design System when developing Login.gov sites to consistently identify the Login.gov brand.
 ---
 
 <section class="usa-section usa-section--dark">

--- a/docs/typography.md
+++ b/docs/typography.md
@@ -10,7 +10,7 @@ lead: >
 Use <code class="text-no-wrap">div.usa-prose</code> to indicate that the immediately containing headings and paragraphs should be considered a longform text document. Or jump to the [Print Guidance](#print-guidance) to learn a bit more about each style.
 
 <div class="border-base-light border-left-1 padding-3 usa-prose">
-  <div class="usa-display">How login.gov keeps personal information private <span class="text-no-wrap text-secondary">(div.usa-display)</span></div>
+  <div class="usa-display">How Login.gov keeps personal information private <span class="text-no-wrap text-secondary">(div.usa-display)</span></div>
 
   <p class="usa-intro">Login.gov encrypts the personal information of each user separately, using a unique value generated from each user’s password. Our encryption method works like a safe deposit box in a bank vault. Only the user has the key. Only the user can open the box to reveal the contents. Only the user knows the password, and only the user can decrypt their information. <span class="text-no-wrap text-secondary">(p.usa-intro)</span></p>
 
@@ -22,19 +22,19 @@ Use <code class="text-no-wrap">div.usa-prose</code> to indicate that the immedia
 
   <p>Individual accounts get a double layer of security. We require two-factor authentication as well as strong passwords that meet new NIST requirements. Two factor authentication requires that you login with your password and a code that we send to your phone.</p>
 
-  <p>We will evaluate and implement new authentication methods as they become widely available to make sure that login.gov remains accessible and secure.</p>
+  <p>We will evaluate and implement new authentication methods as they become widely available to make sure that Login.gov remains accessible and secure.</p>
 
   <h3>Your personal key <span class="text-no-wrap text-secondary">(h3)</span></h3>
 
-  <p>Encrypting personal data separately means that login.gov cannot share any information with other government entities without users’ permission. Not even database administrators can decrypt a user’s personal information without the user’s password.</p>
+  <p>Encrypting personal data separately means that Login.gov cannot share any information with other government entities without users’ permission. Not even database administrators can decrypt a user’s personal information without the user’s password.</p>
 
   <h4>Join us on GitHub <span class="text-no-wrap text-secondary">(h4)</span></h4>
 
   <p>We welcome external review of our privacy-protection measures. All of our code is available for public inspection in an open-source repository. Our goal: make sure that at every step users know their privacy is being protected by design.</p>
 
-  <h5>More information on login.gov <span class="text-no-wrap text-secondary">(h5)</span></h5>
+  <h5>More information on Login.gov <span class="text-no-wrap text-secondary">(h5)</span></h5>
 
-  <p>For more information, please visit the login.gov Help Center or contact us. You can also visit our open-source repository.</p>
+  <p>For more information, please visit the Login.gov Help Center or contact us. You can also visit our open-source repository.</p>
 
   <h6>Simple and secure <span class="text-no-wrap text-secondary">(h6)</span></h6>
 
@@ -42,7 +42,7 @@ Use <code class="text-no-wrap">div.usa-prose</code> to indicate that the immedia
 
   <ul>
     <li>We welcome external review of our privacy-protection measures. All of our code is available for public inspection in an open-source repository. Our goal: make sure that at every step users know their privacy is being protected by design.</li>
-    <li>For more information, please visit the login.gov Help Center or contact us. You can also visit our open-source repository.</li>
+    <li>For more information, please visit the Login.gov Help Center or contact us. You can also visit our open-source repository.</li>
     <li>Dedicated teams of design and security experts will continuously improve it.</li>
   </ul>
 </div>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "identity-style-guide",
   "version": "5.1.0",
-  "description": "The global style of login.gov",
+  "description": "The global style of Login.gov",
   "main": "./build/cjs/index.js",
   "module": "./build/esm/index.js",
   "exports": {

--- a/src/img/favicons/manifest.json
+++ b/src/img/favicons/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "login.gov",
+  "name": "Login.gov",
   "icons": [
     {
       "src": "/android-chrome-192x192.png",


### PR DESCRIPTION
⚠️ This pull request is downstream from #228 and should not be merged in until that PR is merged.

The Login.gov program is removing the branding guidance for using a lowercase "l" when using "Login.gov" in the middle of a sentence. Login.gov is a proper noun and should be used as such to avoid confusion and leverage plain language throughout our branding.

:hat-tip: to @Danielle-Lee