### PR TITLE
Add specific guidance for new capitalization of Login.gov.

### DIFF
--- a/docs/content.md
+++ b/docs/content.md
@@ -64,6 +64,7 @@ Login.gov’s voice is&hellip;
 
 |Correct term or phrase   	|Common errors   	|More information   	|
 |---	|---	|---	|
+|Login.gov   	|Login; login.gov; Login.Gov; LOGIN.gov; LOGIN  	|The “L” in Login.gov is always capitalized. Previous guidance suggested the “L” only be capitalized when at the beginning of a sentence.   	|
 |Online identity proofing, prove your identity   	|Identity verification, verify your identity,   	|   	|
 |two-factor authentication (2FA)   	|multi-factor authentication (MFA)   	|Always write out on first use   	|
 |authentication method   	|authentication device; secondary authentication devise; authentication factor; two-factor authenticator; security option; security method; security factor   	|   	|


### PR DESCRIPTION
This pull request adds in specific guidance on updating Login.gov to always be capitalized, see screenshot.

<img width="759" alt="Screen Shot 2021-07-20 at 1 27 24 PM" src="https://user-images.githubusercontent.com/955558/126369517-41ed7cd9-5e84-4783-b1d3-b030af50261a.png">

Ref #231 