### PR TITLE
Fix integration tests for Color page

### DIFF
--- a/test/color.test.js
+++ b/test/color.test.js
@@ -7,7 +7,7 @@ const rgb2hex = (rgb) => {
 };
 
 test('hex codes match background color on the color documentation page', async () => {
-  await page.goto(`${host}/color/`);
+  await page.goto(`${host}/utilities/color/`);
   const colors = await page.$$eval("[data-test='color-swatch']", (els) =>
     [...els].map((el) => {
       const text = el.innerText.trim();


### PR DESCRIPTION
**Why**: The URL changed from `/color/` to `/utilities/color/` in #233. This updates the integration test accordingly, so that it doesn't fail.