### PR TITLE
Checkbox / Radio Button: Improve HTML whitespace sensitivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Improvements
+
+- Whitespace in checkbox and radio label markup will no longer cause the label text to be misplaced.
+
 ## 6.0.0
 
 ### Breaking Changes

--- a/docs/_components/form-fields.md
+++ b/docs/_components/form-fields.md
@@ -146,23 +146,38 @@ Three styles of radio buttons are provided.
   <ul class="usa-input-list">
     <li>
       <input id="a8c1" class="usa-radio__input usa-radio__input--tile" type="radio" name="a8c1">
-      <label for="a8c1" class="usa-radio__label">Option - Unselected<span class="usa-radio__label-description">Support text</span></label>
+      <label for="a8c1" class="usa-radio__label">
+        Option - Unselected
+        <span class="usa-radio__label-description">Support text</span>
+      </label>
     </li>
     <li>
       <input id="t6wh" class="usa-radio__input usa-radio__input--tile usa-focus" type="radio" name="t6wh">
-      <label for="t6wh" class="usa-radio__label">Option - Unselected Focus<span class="usa-radio__label-description">Support text</span></label>
+      <label for="t6wh" class="usa-radio__label">
+        Option - Unselected Focus
+        <span class="usa-radio__label-description">Support text</span>
+      </label>
     </li>
     <li>
       <input id="b4ed" class="usa-radio__input usa-radio__input--tile" type="radio" name="b4ed" checked>
-      <label for="b4ed" class="usa-radio__label">Option - Selected<span class="usa-radio__label-description">Support text</span></label>
+      <label for="b4ed" class="usa-radio__label">
+        Option - Selected
+        <span class="usa-radio__label-description">Support text</span>
+      </label>
     </li>
     <li>
       <input id="v9h3" class="usa-radio__input usa-radio__input--tile usa-focus" type="radio" name="v9h3" checked>
-      <label for="v9h3" class="usa-radio__label">Option - Selected Focus<span class="usa-radio__label-description">Support text</span></label>
+      <label for="v9h3" class="usa-radio__label">
+        Option - Selected Focus
+        <span class="usa-radio__label-description">Support text</span>
+      </label>
     </li>
     <li>
       <input id="b93f" class="usa-radio__input usa-radio__input--tile" type="radio" name="b93f" disabled>
-      <label for="b93f" class="usa-radio__label">Option - Disabled<span class="usa-radio__label-description">Support text</span></label>
+      <label for="b93f" class="usa-radio__label">
+        Option - Disabled
+        <span class="usa-radio__label-description">Support text</span>
+      </label>
     </li>
   </ul>
 </fieldset>
@@ -243,23 +258,38 @@ Three styles of checkboxes are provided as well.
   <ul class="usa-input-list">
     <li>
       <input id="c288" class="usa-checkbox__input usa-checkbox__input--tile" type="checkbox" name="c288">
-      <label for="c288" class="usa-checkbox__label">Option - Unchecked<span class="usa-checkbox__label-description">Support text</span></label>
+      <label for="c288" class="usa-checkbox__label">
+        Option - Unchecked
+        <span class="usa-checkbox__label-description">Support text</span>
+      </label>
     </li>
     <li>
       <input id="u22j" class="usa-checkbox__input usa-checkbox__input--tile usa-focus" type="checkbox" name="u22j">
-      <label for="u22j" class="usa-checkbox__label">Option - Unchecked Focus<span class="usa-checkbox__label-description">Support text</span></label>
+      <label for="u22j" class="usa-checkbox__label">
+        Option - Unchecked Focus
+        <span class="usa-checkbox__label-description">Support text</span>
+      </label>
     </li>
     <li>
       <input id="e484" class="usa-checkbox__input usa-checkbox__input--tile" type="checkbox" name="e484" checked>
-      <label for="e484" class="usa-checkbox__label">Option - Checked<span class="usa-checkbox__label-description">Support text</span></label>
+      <label for="e484" class="usa-checkbox__label">
+        Option - Checked
+        <span class="usa-checkbox__label-description">Support text</span>
+      </label>
     </li>
     <li>
       <input id="afeg" class="usa-checkbox__input usa-checkbox__input--tile usa-focus" type="checkbox" name="afeg" checked>
-      <label for="afeg" class="usa-checkbox__label">Option - Checked Focus<span class="usa-checkbox__label-description">Support text</span></label>
+      <label for="afeg" class="usa-checkbox__label">
+        Option - Checked Focus
+        <span class="usa-checkbox__label-description">Support text</span>
+      </label>
     </li>
     <li>
       <input id="ea84" class="usa-checkbox__input usa-checkbox__input--tile" type="checkbox" name="ea84" disabled>
-      <label for="ea84" class="usa-checkbox__label">Option - Disabled<span class="usa-checkbox__label-description">Support text</span></label>
+      <label for="ea84" class="usa-checkbox__label">
+        Option - Disabled
+        <span class="usa-checkbox__label-description">Support text</span>
+      </label>
     </li>
   </ul>
 </fieldset>

--- a/docs/_components/form-fields.md
+++ b/docs/_components/form-fields.md
@@ -146,38 +146,23 @@ Three styles of radio buttons are provided.
   <ul class="usa-input-list">
     <li>
       <input id="a8c1" class="usa-radio__input usa-radio__input--tile" type="radio" name="a8c1">
-      <label for="a8c1" class="usa-radio__label">
-        Option - Unselected
-        <span class="usa-radio__label-description">Support text</span>
-      </label>
+      <label for="a8c1" class="usa-radio__label">Option - Unselected<span class="usa-radio__label-description">Support text</span></label>
     </li>
     <li>
       <input id="t6wh" class="usa-radio__input usa-radio__input--tile usa-focus" type="radio" name="t6wh">
-      <label for="t6wh" class="usa-radio__label">
-        Option - Unselected Focus
-        <span class="usa-radio__label-description">Support text</span>
-      </label>
+      <label for="t6wh" class="usa-radio__label">Option - Unselected Focus<span class="usa-radio__label-description">Support text</span></label>
     </li>
     <li>
       <input id="b4ed" class="usa-radio__input usa-radio__input--tile" type="radio" name="b4ed" checked>
-      <label for="b4ed" class="usa-radio__label">
-        Option - Selected
-        <span class="usa-radio__label-description">Support text</span>
-      </label>
+      <label for="b4ed" class="usa-radio__label">Option - Selected<span class="usa-radio__label-description">Support text</span></label>
     </li>
     <li>
       <input id="v9h3" class="usa-radio__input usa-radio__input--tile usa-focus" type="radio" name="v9h3" checked>
-      <label for="v9h3" class="usa-radio__label">
-        Option - Selected Focus
-        <span class="usa-radio__label-description">Support text</span>
-      </label>
+      <label for="v9h3" class="usa-radio__label">Option - Selected Focus<span class="usa-radio__label-description">Support text</span></label>
     </li>
     <li>
       <input id="b93f" class="usa-radio__input usa-radio__input--tile" type="radio" name="b93f" disabled>
-      <label for="b93f" class="usa-radio__label">
-        Option - Disabled
-        <span class="usa-radio__label-description">Support text</span>
-      </label>
+      <label for="b93f" class="usa-radio__label">Option - Disabled<span class="usa-radio__label-description">Support text</span></label>
     </li>
   </ul>
 </fieldset>
@@ -258,38 +243,23 @@ Three styles of checkboxes are provided as well.
   <ul class="usa-input-list">
     <li>
       <input id="c288" class="usa-checkbox__input usa-checkbox__input--tile" type="checkbox" name="c288">
-      <label for="c288" class="usa-checkbox__label">
-        Option - Unchecked
-        <span class="usa-checkbox__label-description">Support text</span>
-      </label>
+      <label for="c288" class="usa-checkbox__label">Option - Unchecked<span class="usa-checkbox__label-description">Support text</span></label>
     </li>
     <li>
       <input id="u22j" class="usa-checkbox__input usa-checkbox__input--tile usa-focus" type="checkbox" name="u22j">
-      <label for="u22j" class="usa-checkbox__label">
-        Option - Unchecked Focus
-        <span class="usa-checkbox__label-description">Support text</span>
-      </label>
+      <label for="u22j" class="usa-checkbox__label">Option - Unchecked Focus<span class="usa-checkbox__label-description">Support text</span></label>
     </li>
     <li>
       <input id="e484" class="usa-checkbox__input usa-checkbox__input--tile" type="checkbox" name="e484" checked>
-      <label for="e484" class="usa-checkbox__label">
-        Option - Checked
-        <span class="usa-checkbox__label-description">Support text</span>
-      </label>
+      <label for="e484" class="usa-checkbox__label">Option - Checked<span class="usa-checkbox__label-description">Support text</span></label>
     </li>
     <li>
       <input id="afeg" class="usa-checkbox__input usa-checkbox__input--tile usa-focus" type="checkbox" name="afeg" checked>
-      <label for="afeg" class="usa-checkbox__label">
-        Option - Checked Focus
-        <span class="usa-checkbox__label-description">Support text</span>
-      </label>
+      <label for="afeg" class="usa-checkbox__label">Option - Checked Focus<span class="usa-checkbox__label-description">Support text</span></label>
     </li>
     <li>
       <input id="ea84" class="usa-checkbox__input usa-checkbox__input--tile" type="checkbox" name="ea84" disabled>
-      <label for="ea84" class="usa-checkbox__label">
-        Option - Disabled
-        <span class="usa-checkbox__label-description">Support text</span>
-      </label>
+      <label for="ea84" class="usa-checkbox__label">Option - Disabled<span class="usa-checkbox__label-description">Support text</span></label>
     </li>
   </ul>
 </fieldset>

--- a/src/scss/components/_inputs.scss
+++ b/src/scss/components/_inputs.scss
@@ -194,18 +194,6 @@ $checkbox-radio-size: .875rem;
   @include u-text('ink', 'normal');
 }
 
-.usa-radio-header,
-.usa-checkbox-header {
-  @include typeset('sans', 7, 1);
-  display: inline-block;
-  color: color('primary');
-  margin: 0;
-
-  & + * {
-    margin-top: units(.5);
-  }
-}
-
 .usa-legend {
   @include u-font-size('sans', '2xs');
   text-transform: uppercase;

--- a/src/scss/components/_inputs.scss
+++ b/src/scss/components/_inputs.scss
@@ -10,6 +10,7 @@ $input-padding: 1;
 $icon-size: 2;
 $border-width: 1px;
 $checkbox-radio-size: .875rem;
+$input-select-margin-right: 1;
 
 .usa-input,
 .usa-textarea {
@@ -77,6 +78,7 @@ $checkbox-radio-size: .875rem;
   @extend %block-input-general;
   display: inline-block;
   margin-bottom: units(1);
+  padding-left: $checkbox-radio-size + units($input-select-margin-right);
   text-indent: 0;
 
   &::before {
@@ -84,7 +86,7 @@ $checkbox-radio-size: .875rem;
     box-shadow: inset 0 0 0 units($border-width) color('primary');
     display: block;
     height: $checkbox-radio-size;
-    left: units(.5);
+    left: 0;
     margin-left: 0;
     margin-right: 0;
     margin-top: (
@@ -170,14 +172,14 @@ $checkbox-radio-size: .875rem;
   border-radius: radius($theme-input-bordered-border-radius);
   margin: units(1) 0;
   max-width: units($theme-input-max-width);
-  padding: units(1) units(2) units(1) units(5);
+  padding: units(1) units(2) units(1) #{units(2) + $checkbox-radio-size + units($input-select-margin-right)};
 }
 
 .usa-checkbox__input--tile + .usa-checkbox__label::before,
 .usa-radio__input--tile + .usa-radio__label::before,
 .usa-radio__input--bordered + .usa-radio__label::before,
 .usa-checkbox__input--bordered + .usa-checkbox__label::before {
-  left: units(5) - units($input-select-margin-right) - $checkbox-radio-size;
+  left: units(2);
 }
 
 .usa-checkbox__input--bordered:checked + .usa-checkbox__label,

--- a/src/scss/components/_inputs.scss
+++ b/src/scss/components/_inputs.scss
@@ -75,6 +75,8 @@ $checkbox-radio-size: .875rem;
 .usa-radio__label,
 .usa-checkbox__label {
   @extend %block-input-general;
+  display: inline-block;
+  margin-bottom: units(1);
   text-indent: 0;
 
   &::before {

--- a/src/scss/components/_inputs.scss
+++ b/src/scss/components/_inputs.scss
@@ -74,26 +74,32 @@ $checkbox-radio-size: .875rem;
 
 .usa-radio__label,
 .usa-checkbox__label {
-  display: inline-block;
-  margin-bottom: units(1);
+  @extend %block-input-general;
+  text-indent: 0;
+
+  &::before {
+    background-color: color('primary-lightest');
+    box-shadow: inset 0 0 0 units($border-width) color('primary');
+    display: block;
+    height: $checkbox-radio-size;
+    left: units(.5);
+    margin-left: 0;
+    margin-right: 0;
+    margin-top: (
+      line-height($theme-form-font-family, $theme-input-line-height) *
+      font-size($theme-form-font-family, $theme-body-font-size) -
+      $checkbox-radio-size
+    ) / 2;
+    position: absolute;
+    white-space: normal;
+    width: $checkbox-radio-size;
+  }
 }
 
 .usa-radio__input:disabled + .usa-radio__label,
 .usa-checkbox__input:disabled + .usa-checkbox__label {
   color: color('disabled');
   border-color: color('disabled');
-}
-
-.usa-radio__label::before,
-.usa-checkbox__label::before {
-  background-color: color('primary-lightest');
-  box-shadow: inset 0 0 0 units($border-width) color('primary');
-  height: $checkbox-radio-size;
-  line-height: $checkbox-radio-size;
-  margin-left: units(.5);
-  // Margin = Default margin + difference from default width, with custom offset, on one side.
-  margin-right: units($input-select-margin-right) + (units($theme-input-select-size) - $checkbox-radio-size - units(.5)) / 2;
-  width: $checkbox-radio-size;
 }
 
 .usa-radio__label::before {
@@ -163,6 +169,13 @@ $checkbox-radio-size: .875rem;
   margin: units(1) 0;
   max-width: units($theme-input-max-width);
   padding: units(1) units(2) units(1) units(5);
+}
+
+.usa-checkbox__input--tile + .usa-checkbox__label::before,
+.usa-radio__input--tile + .usa-radio__label::before,
+.usa-radio__input--bordered + .usa-radio__label::before,
+.usa-checkbox__input--bordered + .usa-checkbox__label::before {
+  left: units(5) - units($input-select-margin-right) - $checkbox-radio-size;
 }
 
 .usa-checkbox__input--bordered:checked + .usa-checkbox__label,


### PR DESCRIPTION
Related: https://github.com/uswds/uswds/pull/4286
Context: https://github.com/18F/identity-idp/pull/5279#discussion_r686146591

This pull request seeks to maintain the existing visual appearance of the Checkbox and Radio Button components, while improving developer ergonomics regarding HTML whitespace sensitivity.

See additional details at https://github.com/uswds/uswds/pull/4286 .

The expectation is that there should be no user-facing visual effect of these changes, hopefully demonstrated by a passing visual regression test.

This does not incorporate [other design revisions proposed for the checkbox and radio component](https://gsa-tts.slack.com/archives/C01JVKYE4KD/p1628869289001500), which will be implemented separately.