### PR TITLE
Increase external link margin styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Improvements
 
 - Whitespace in checkbox and radio label markup will no longer cause the label text to be misplaced.
+- Margins surrounding an external link icon have been increased slightly.
 
 ## 6.0.0
 

--- a/src/scss/components/_links.scss
+++ b/src/scss/components/_links.scss
@@ -1,0 +1,4 @@
+.usa-link--external::after {
+  margin-left: units(.5);
+  margin-right: units(2px);
+}

--- a/src/scss/packages/_components.scss
+++ b/src/scss/packages/_components.scss
@@ -10,6 +10,7 @@
 @import '../components/general';
 @import '../components/hero';
 @import '../components/inputs';
+@import '../components/links';
 @import '../components/navbar';
 @import '../components/sidenav';
 @import '../components/spinner';


### PR DESCRIPTION
Backported from https://github.com/18F/identity-idp/pull/5300 (see [design feedback](https://github.com/18F/identity-idp/pull/5300#pullrequestreview-734356031))

This adds a small additional buffer between the external link icon and surrounding text, previous 2px left margin and 0px right margin, now 4px left margin and 2px right margin.

Before|After
---|---
![image](https://user-images.githubusercontent.com/1779930/130687979-e0d39ade-bd24-4a84-b8eb-74c1ab4ddc92.png)|![image](https://user-images.githubusercontent.com/1779930/130688006-cdeb0b13-3385-4bca-8b29-cc4474607545.png)

Live preview: https://federalist-2f194a10-945e-4413-be01-46ca6dae5358.app.cloud.gov/preview/18f/identity-style-guide/aduth-external-link-margin/components/accordions/

Visual regression tests are expected to fail.