### PR TITLE
Increase padding and font size for tile checkbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Whitespace in checkbox and radio label markup will no longer cause the label text to be misplaced.
 - Margins surrounding an external link icon have been increased slightly.
+- Padding and label font size for tile checkboxes and radio buttons have increased slightly.
 
 ## 6.0.0
 

--- a/src/scss/components/_inputs.scss
+++ b/src/scss/components/_inputs.scss
@@ -75,7 +75,6 @@ $input-select-margin-right: 1;
 
 .usa-radio__label,
 .usa-checkbox__label {
-  @include u-font-size($theme-form-font-family, 'md');
   @extend %block-input-general;
   display: inline-block;
   margin-bottom: units(1);
@@ -92,7 +91,7 @@ $input-select-margin-right: 1;
     margin-right: 0;
     margin-top: (
       line-height($theme-form-font-family, $theme-input-line-height) *
-      font-size($theme-form-font-family, 'md') -
+      font-size($theme-form-font-family, $theme-body-font-size) -
       $checkbox-radio-size
     ) / 2;
     position: absolute;
@@ -159,12 +158,22 @@ $input-select-margin-right: 1;
 
 .usa-checkbox__input--tile + .usa-checkbox__label,
 .usa-radio__input--tile + .usa-radio__label {
+  @include u-font-size($theme-form-font-family, 'md');
   @include u-text('primary', 'bold');
   @include u-display('block');
   @include u-padding(3);
   padding-left: units(3) + $checkbox-radio-size + $input-select-margin-right;
   background-color: color($theme-input-tile-background-color); // https://github.com/uswds/uswds/pull/4178
   max-width: units($theme-input-max-width);
+
+  &::before {
+    left: units(3);
+    margin-top: (
+      line-height($theme-form-font-family, $theme-input-line-height) *
+      font-size($theme-form-font-family, 'md') -
+      $checkbox-radio-size
+    ) / 2;
+  }
 }
 
 .usa-radio__input--bordered + .usa-radio__label,
@@ -176,13 +185,10 @@ $input-select-margin-right: 1;
   margin: units(1) 0;
   max-width: units($theme-input-max-width);
   padding: units(1) units(2) units(1) #{units(2) + $checkbox-radio-size + units($input-select-margin-right)};
-}
 
-.usa-checkbox__input--tile + .usa-checkbox__label::before,
-.usa-radio__input--tile + .usa-radio__label::before,
-.usa-radio__input--bordered + .usa-radio__label::before,
-.usa-checkbox__input--bordered + .usa-checkbox__label::before {
-  left: units(3);
+  &::before {
+    left: units(2);
+  }
 }
 
 .usa-checkbox__input--bordered:checked + .usa-checkbox__label,

--- a/src/scss/components/_inputs.scss
+++ b/src/scss/components/_inputs.scss
@@ -75,6 +75,7 @@ $input-select-margin-right: 1;
 
 .usa-radio__label,
 .usa-checkbox__label {
+  @include u-font-size($theme-form-font-family, 'md');
   @extend %block-input-general;
   display: inline-block;
   margin-bottom: units(1);
@@ -91,7 +92,7 @@ $input-select-margin-right: 1;
     margin-right: 0;
     margin-top: (
       line-height($theme-form-font-family, $theme-input-line-height) *
-      font-size($theme-form-font-family, $theme-body-font-size) -
+      font-size($theme-form-font-family, 'md') -
       $checkbox-radio-size
     ) / 2;
     position: absolute;
@@ -160,6 +161,8 @@ $input-select-margin-right: 1;
 .usa-radio__input--tile + .usa-radio__label {
   @include u-text('primary', 'bold');
   @include u-display('block');
+  @include u-padding(3);
+  padding-left: units(3) + $checkbox-radio-size + $input-select-margin-right;
   background-color: color($theme-input-tile-background-color); // https://github.com/uswds/uswds/pull/4178
   max-width: units($theme-input-max-width);
 }
@@ -179,7 +182,7 @@ $input-select-margin-right: 1;
 .usa-radio__input--tile + .usa-radio__label::before,
 .usa-radio__input--bordered + .usa-radio__label::before,
 .usa-checkbox__input--bordered + .usa-checkbox__label::before {
-  left: units(2);
+  left: units(3);
 }
 
 .usa-checkbox__input--bordered:checked + .usa-checkbox__label,


### PR DESCRIPTION
Related: https://github.com/18F/identity-idp/pull/5279#pullrequestreview-727676760
Slack discussion: https://gsa-tts.slack.com/archives/C01JVKYE4KD/p1628869289001500

Implements padding and font size for tile variants of checkbox and radio buttons to align to Figma designs.

**Screenshots:**

Before|After
---|---
![image](https://user-images.githubusercontent.com/1779930/130792012-a98c14e0-4425-4b76-9e3e-94632af9fc7e.png)|![image](https://user-images.githubusercontent.com/1779930/130792362-160327c5-f770-4016-9da2-dc34329b0fed.png)

**Live Preview:**

- Before: https://design.login.gov/components/form-fields/#tile
- After: https://federalist-2f194a10-945e-4413-be01-46ca6dae5358.app.cloud.gov/preview/18f/identity-style-guide/aduth-check-tile-padding/components/form-fields/#tile