### PR TITLE
Improve package-lock.json validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ validate-gemfile-lock: Gemfile Gemfile.lock
 validate-package-lock: package.json package-lock.json
 	@echo "Validating package-lock.json..."
 	@npm install --ignore-scripts
-	@git diff-index --quiet HEAD package-lock.json || (echo "Error: There are uncommitted changes after running 'npm install'"; exit 1)
+	@(! git diff --name-only | grep package-lock.json) || (echo "Error: There are uncommitted changes after running 'npm install'"; exit 1)
 
 validate-lockfiles: validate-gemfile-lock validate-package-lock
 


### PR DESCRIPTION
**Why**: To avoid false positives where `npm install` may touch `package-lock.json` without actually making content changes.

See: https://github.com/npm/cli/issues/3225

`git diff-index` doesn't always accurately reflect the content of the file itself:

>As with other commands of this type, git diff-index does not actually look at the contents of the file at all. So maybe kernel/sched.c hasn’t actually changed, and it’s just that you touched it. In either case, it’s a note that you need to git update-index it to make the index be in sync.

Via: https://git-scm.com/docs/git-diff-index

Also aligns with similar implementations in other Login.gov repositories, e.g.: https://github.com/18F/identity-idp/blob/278823d3622dff0f42a50a9ff6a23f0a036e4602/Makefile#L58-L59