### PR TITLE
Define all variables as default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### New Features
+
+- All theme variables are now set as [default values](https://sass-lang.com/documentation/variables#default-values), allowing you to override them for per-project requirements.
+  - Note: Since the design system is meant to be an opinionated set of smart defaults, it's recommended to use restraint with variable customization, or at least consider when it may be more appropriate to adjust a setting from the design system itself in order to maintain consistency across projects.
+
 ## 6.1.0
 
 ### Improvements

--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ Below are various ways to use the Login.gov Design System throughout our various
  ```scss
  // app/assets/stylesheets/application.css.scss
 
- $font-path: 'fonts';
- $image-path: 'img';
+ $theme-font-path: 'fonts';
+ $theme-image-path: 'img';
 
  @import 'identity-style-guide/dist/assets/scss/styles';
  ```

--- a/src/scss/uswds-theme/_color.scss
+++ b/src/scss/uswds-theme/_color.scss
@@ -78,45 +78,45 @@ Theme palette colors
 */
 
 // Base colors
-$theme-color-base-family: 'grey';
-$theme-color-base-lightest: map-get($site-palette, 'site-lightest-grey');
-$theme-color-base-lighter: map-get($site-palette, 'site-lighter-grey');
-$theme-color-base-light: map-get($site-palette, 'site-light-grey');
-$theme-color-base: map-get($site-palette, 'site-grey');
-$theme-color-base-dark: map-get($site-palette, 'site-dark-grey');
-$theme-color-base-darker: map-get($site-palette, 'site-darker-grey');
-$theme-color-base-darkest: map-get($site-palette, 'site-darkest-grey');
-$theme-color-base-ink: map-get($site-palette, 'site-ink');
+$theme-color-base-family: 'grey' !default;
+$theme-color-base-lightest: map-get($site-palette, 'site-lightest-grey') !default;
+$theme-color-base-lighter: map-get($site-palette, 'site-lighter-grey') !default;
+$theme-color-base-light: map-get($site-palette, 'site-light-grey') !default;
+$theme-color-base: map-get($site-palette, 'site-grey') !default;
+$theme-color-base-dark: map-get($site-palette, 'site-dark-grey') !default;
+$theme-color-base-darker: map-get($site-palette, 'site-darker-grey') !default;
+$theme-color-base-darkest: map-get($site-palette, 'site-darkest-grey') !default;
+$theme-color-base-ink: map-get($site-palette, 'site-ink') !default;
 
 // Primary colors
-$theme-color-primary-lightest: map-get($site-palette, 'site-lightest-blue');
-$theme-color-primary-lighter: map-get($site-palette, 'site-lighter-blue');
-$theme-color-primary-light: map-get($site-palette, 'site-light-blue');
-$theme-color-primary: map-get($site-palette, 'site-blue');
-$theme-color-primary-vivid: map-get($site-palette, 'site-blue');
-$theme-color-primary-dark: map-get($site-palette, 'site-dark-blue');
-$theme-color-primary-darker: map-get($site-palette, 'site-darker-blue');
-$theme-color-primary-darkest: map-get($site-palette, 'site-darkest-blue');
+$theme-color-primary-lightest: map-get($site-palette, 'site-lightest-blue') !default;
+$theme-color-primary-lighter: map-get($site-palette, 'site-lighter-blue') !default;
+$theme-color-primary-light: map-get($site-palette, 'site-light-blue') !default;
+$theme-color-primary: map-get($site-palette, 'site-blue') !default;
+$theme-color-primary-vivid: map-get($site-palette, 'site-blue') !default;
+$theme-color-primary-dark: map-get($site-palette, 'site-dark-blue') !default;
+$theme-color-primary-darker: map-get($site-palette, 'site-darker-blue') !default;
+$theme-color-primary-darkest: map-get($site-palette, 'site-darkest-blue') !default;
 
 // Secondary colors
-$theme-color-secondary-lightest: map-get($site-palette, 'site-lightest-red');
-$theme-color-secondary-lighter: map-get($site-palette, 'site-lighter-red');
-$theme-color-secondary-light: map-get($site-palette, 'site-light-red');
-$theme-color-secondary: map-get($site-palette, 'site-red');
-$theme-color-secondary-vivid: false;
-$theme-color-secondary-dark: map-get($site-palette, 'site-dark-red');
-$theme-color-secondary-darker: map-get($site-palette, 'site-darker-red');
-$theme-color-secondary-darkest: map-get($site-palette, 'site-darkest-red');
+$theme-color-secondary-lightest: map-get($site-palette, 'site-lightest-red') !default;
+$theme-color-secondary-lighter: map-get($site-palette, 'site-lighter-red') !default;
+$theme-color-secondary-light: map-get($site-palette, 'site-light-red') !default;
+$theme-color-secondary: map-get($site-palette, 'site-red') !default;
+$theme-color-secondary-vivid: false !default;
+$theme-color-secondary-dark: map-get($site-palette, 'site-dark-red') !default;
+$theme-color-secondary-darker: map-get($site-palette, 'site-darker-red') !default;
+$theme-color-secondary-darkest: map-get($site-palette, 'site-darkest-red') !default;
 
 // Accent cool colors
-$theme-color-accent-cool-family: 'teal';
-$theme-color-accent-cool-lightest: map-get($site-palette, 'site-lightest-teal');
-$theme-color-accent-cool-lighter: map-get($site-palette, 'site-lighter-teal');
-$theme-color-accent-cool-light: map-get($site-palette, 'site-light-teal');
-$theme-color-accent-cool: map-get($site-palette, 'site-teal');
-$theme-color-accent-cool-dark: map-get($site-palette, 'site-dark-teal');
-$theme-color-accent-cool-darker: map-get($site-palette, 'site-darker-teal');
-$theme-color-accent-cool-darkest: map-get($site-palette, 'site-darkest-teal');
+$theme-color-accent-cool-family: 'teal' !default;
+$theme-color-accent-cool-lightest: map-get($site-palette, 'site-lightest-teal') !default;
+$theme-color-accent-cool-lighter: map-get($site-palette, 'site-lighter-teal') !default;
+$theme-color-accent-cool-light: map-get($site-palette, 'site-light-teal') !default;
+$theme-color-accent-cool: map-get($site-palette, 'site-teal') !default;
+$theme-color-accent-cool-dark: map-get($site-palette, 'site-dark-teal') !default;
+$theme-color-accent-cool-darker: map-get($site-palette, 'site-darker-teal') !default;
+$theme-color-accent-cool-darkest: map-get($site-palette, 'site-darkest-teal') !default;
 
 /*
 ----------------------------------------
@@ -125,38 +125,38 @@ State palette colors
 */
 
 // Error colors
-$theme-color-error-family: 'red';
-$theme-color-error-lighter: map-get($site-palette, 'site-lightest-red');
-$theme-color-error-light: map-get($site-palette, 'site-lighter-red');
-$theme-color-error: map-get($site-palette, 'site-red');
-$theme-color-error-dark: map-get($site-palette, 'site-darker-red');
-$theme-color-error-darker: map-get($site-palette, 'site-darkest-red');
+$theme-color-error-family: 'red' !default;
+$theme-color-error-lighter: map-get($site-palette, 'site-lightest-red') !default;
+$theme-color-error-light: map-get($site-palette, 'site-lighter-red') !default;
+$theme-color-error: map-get($site-palette, 'site-red') !default;
+$theme-color-error-dark: map-get($site-palette, 'site-darker-red') !default;
+$theme-color-error-darker: map-get($site-palette, 'site-darkest-red') !default;
 
 // Warning colors
-$theme-color-warning-family: 'yellow';
-$theme-color-warning-lighter: map-get($site-palette, 'site-lightest-yellow');
-$theme-color-warning-light: map-get($site-palette, 'site-lighter-yellow');
-$theme-color-warning: map-get($site-palette, 'site-yellow');
-$theme-color-warning-dark: map-get($site-palette, 'site-darker-yellow');
-$theme-color-warning-darker: map-get($site-palette, 'site-darkest-yellow');
+$theme-color-warning-family: 'yellow' !default;
+$theme-color-warning-lighter: map-get($site-palette, 'site-lightest-yellow') !default;
+$theme-color-warning-light: map-get($site-palette, 'site-lighter-yellow') !default;
+$theme-color-warning: map-get($site-palette, 'site-yellow') !default;
+$theme-color-warning-dark: map-get($site-palette, 'site-darker-yellow') !default;
+$theme-color-warning-darker: map-get($site-palette, 'site-darkest-yellow') !default;
 
 // Success colors
-$theme-color-success-family: 'green';
-$theme-color-success-lighter: map-get($site-palette, 'site-lightest-green');
-$theme-color-success-light: map-get($site-palette, 'site-lighter-green');
-$theme-color-success: map-get($site-palette, 'site-green');
-$theme-color-success-dark: map-get($site-palette, 'site-darker-green');
-$theme-color-success-darker: map-get($site-palette, 'site-darkest-green');
+$theme-color-success-family: 'green' !default;
+$theme-color-success-lighter: map-get($site-palette, 'site-lightest-green') !default;
+$theme-color-success-light: map-get($site-palette, 'site-lighter-green') !default;
+$theme-color-success: map-get($site-palette, 'site-green') !default;
+$theme-color-success-dark: map-get($site-palette, 'site-darker-green') !default;
+$theme-color-success-darker: map-get($site-palette, 'site-darkest-green') !default;
 
 // Info colors
-$theme-color-info-family: 'teal';
-$theme-color-info-lighter: map-get($site-palette, 'site-lightest-teal');
-$theme-color-info-light: map-get($site-palette, 'site-lighter-teal');
-$theme-color-info: map-get($site-palette, 'site-teal');
-$theme-color-info-dark: map-get($site-palette, 'site-darker-teal');
-$theme-color-info-darker: map-get($site-palette, 'site-darkest-teal');
+$theme-color-info-family: 'teal' !default;
+$theme-color-info-lighter: map-get($site-palette, 'site-lightest-teal') !default;
+$theme-color-info-light: map-get($site-palette, 'site-lighter-teal') !default;
+$theme-color-info: map-get($site-palette, 'site-teal') !default;
+$theme-color-info-dark: map-get($site-palette, 'site-darker-teal') !default;
+$theme-color-info-darker: map-get($site-palette, 'site-darkest-teal') !default;
 
 // Disabled colors
-$theme-color-disabled-light: map-get($site-palette, 'site-lightest-grey');
-$theme-color-disabled: map-get($site-palette, 'site-disabled-grey');
-$theme-color-disabled-dark: map-get($site-palette, 'site-darker-grey');
+$theme-color-disabled-light: map-get($site-palette, 'site-lightest-grey') !default;
+$theme-color-disabled: map-get($site-palette, 'site-disabled-grey') !default;
+$theme-color-disabled-dark: map-get($site-palette, 'site-darker-grey') !default;

--- a/src/scss/uswds-theme/_components.scss
+++ b/src/scss/uswds-theme/_components.scss
@@ -16,26 +16,26 @@ https://designsystem.digital.gov/design-tokens
 */
 
 // Accordion
-$theme-accordion-border-width: '1px';
-$theme-accordion-border-color: 'primary-light';
+$theme-accordion-border-width: '1px' !default;
+$theme-accordion-border-color: 'primary-light' !default;
 
 // Alert
-$theme-alert-bar-width: 0;
-$theme-alert-icon-size: 2;
-$theme-alert-padding-x: 2;
-$theme-alert-padding-y: '105';
+$theme-alert-bar-width: 0 !default;
+$theme-alert-icon-size: 2 !default;
+$theme-alert-padding-x: 2 !default;
+$theme-alert-padding-y: '105' !default;
 
 // Banner
-$theme-banner-background-color: 'primary-lighter';
+$theme-banner-background-color: 'primary-lighter' !default;
 
 // Button
-$theme-button-stroke-width: 1px;
+$theme-button-stroke-width: 1px !default;
 
 // Footer
-$theme-footer-font-family: 'body';
+$theme-footer-font-family: 'body' !default;
 
 // Form and input
-$theme-checkbox-border-radius: 1.5px;
-$theme-input-line-height: 3;
-$theme-input-tile-border-radius: 'lg';
-$theme-input-tile-border-width: 1px;
+$theme-checkbox-border-radius: 1.5px !default;
+$theme-input-line-height: 3 !default;
+$theme-input-tile-border-radius: 'lg' !default;
+$theme-input-tile-border-width: 1px !default;

--- a/src/scss/uswds-theme/_general.scss
+++ b/src/scss/uswds-theme/_general.scss
@@ -23,7 +23,7 @@ Relative image file path
 ----------------------------------------
 */
 
-$theme-image-path: if(variable-exists(image-path), $image-path, '../img');
+$theme-image-path: if(variable-exists(image-path), $image-path, '../img') !default;
 
 /*
 ----------------------------------------
@@ -34,8 +34,8 @@ mixins use nonstanard or false tokens.
 ----------------------------------------
 */
 
-$theme-show-compile-warnings: false;
-$theme-show-notifications: false;
+$theme-show-compile-warnings: false !default;
+$theme-show-notifications: false !default;
 
 /*
 ----------------------------------------
@@ -43,6 +43,6 @@ Focus styles
 ----------------------------------------
 */
 
-$theme-focus-color: 'primary';
-$theme-focus-offset: 1px;
-$theme-focus-width: 2px;
+$theme-focus-color: 'primary' !default;
+$theme-focus-offset: 1px !default;
+$theme-focus-width: 2px !default;

--- a/src/scss/uswds-theme/_typography.scss
+++ b/src/scss/uswds-theme/_typography.scss
@@ -35,7 +35,7 @@ Accepts true or false
 ----------------------------------------
 */
 
-$theme-respect-user-font-size: false;
+$theme-respect-user-font-size: false !default;
 
 // $theme-root-font-size only applies when
 // $theme-respect-user-font-size is set to
@@ -47,7 +47,7 @@ $theme-respect-user-font-size: false;
 
 // Accepts values in px
 
-$theme-root-font-size: 16px;
+$theme-root-font-size: 16px !default;
 
 /*
 ----------------------------------------
@@ -57,7 +57,7 @@ Relative font file path
 ----------------------------------------
 */
 
-$theme-font-path: if(variable-exists(font-path), $font-path, '../fonts');
+$theme-font-path: if(variable-exists(font-path), $font-path, '../fonts') !default;
 
 /*
 ----------------------------------------
@@ -70,9 +70,9 @@ values from the USWDS system type scale
 ----------------------------------------
 */
 
-$theme-type-scale-3xs: 'micro';
-$theme-type-scale-2xs: 2;
-$theme-type-scale-xl: 11;
+$theme-type-scale-3xs: 'micro' !default;
+$theme-type-scale-2xs: 2 !default;
+$theme-type-scale-xl: 11 !default;
 
 /*
 ----------------------------------------
@@ -132,22 +132,22 @@ none:    none
 */
 
 // Body settings are the equivalent of setting the <body> element
-$theme-body-font-size: 'xs';
+$theme-body-font-size: 'xs' !default;
 
 // Headings
-$theme-h1-font-size: 'xl';
-$theme-h2-font-size: 'lg';
-$theme-h3-font-size: 'md';
-$theme-h4-font-size: 'xs';
-$theme-h5-font-size: '2xs';
-$theme-heading-line-height: 3;
-$theme-display-font-size: '2xl';
+$theme-h1-font-size: 'xl' !default;
+$theme-h2-font-size: 'lg' !default;
+$theme-h3-font-size: 'md' !default;
+$theme-h4-font-size: 'xs' !default;
+$theme-h5-font-size: '2xs' !default;
+$theme-heading-line-height: 3 !default;
+$theme-display-font-size: '2xl' !default;
 
 // Text and prose
-$theme-text-measure: 3;
-$theme-text-measure-wide: 4;
+$theme-text-measure: 3 !default;
+$theme-text-measure-wide: 4 !default;
 
 // Lead text
-$theme-lead-font-family: 'body';
-$theme-lead-font-size: 8;
-$theme-lead-measure: 5;
+$theme-lead-font-family: 'body' !default;
+$theme-lead-font-size: 8 !default;
+$theme-lead-measure: 5 !default;

--- a/src/scss/uswds-theme/_utilities.scss
+++ b/src/scss/uswds-theme/_utilities.scss
@@ -30,7 +30,7 @@ The following palettes will be added to
 $global-color-palettes: (
   'palette-color-default',
   'palette-color-state',
-);
+) !default;
 
 /*
 ----------------------------------------
@@ -45,4 +45,4 @@ $width-settings: (
   focus: false,
   hover: false,
   visited: false,
-);
+) !default;


### PR DESCRIPTION
**Why**: To allow per-project customization, which previously required cumbersome workarounds.

Documentation: https://sass-lang.com/documentation/variables#default-values

Real-world examples: https://github.com/18F/identity-site/search?l=SCSS&q=todo