### PR TITLE
Remove width non-responsive override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - All theme variables are now set as [default values](https://sass-lang.com/documentation/variables#default-values), allowing you to override them for per-project requirements.
   - Note: Since the design system is meant to be an opinionated set of smart defaults, it's recommended to use restraint with variable customization, or at least consider when it may be more appropriate to adjust a setting from the design system itself in order to maintain consistency across projects.
+- Responsive variants of width utility classes are now enabled.
 
 ## 6.1.0
 

--- a/src/scss/uswds-theme/_utilities.scss
+++ b/src/scss/uswds-theme/_utilities.scss
@@ -31,18 +31,3 @@ $global-color-palettes: (
   'palette-color-default',
   'palette-color-state',
 ) !default;
-
-/*
-----------------------------------------
-Settings
-----------------------------------------
-*/
-
-$width-settings: (
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;


### PR DESCRIPTION
**Why**: These were kept in #236 as they differed from USWDS defaults, but they _were_ identical to the default as of the original file creation. USWDS later [changed the default](https://github.com/uswds/uswds/commit/16806bde246f61207cd64bfbf2e21c5a3a8b998b), and since we had no explicit reason to disable responsive styles, we should inherit the default instead.