### PR TITLE
Remove uppercase transform from navbar styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
   - Note: Since the design system is meant to be an opinionated set of smart defaults, it's recommended to use restraint with variable customization, or at least consider when it may be more appropriate to adjust a setting from the design system itself in order to maintain consistency across projects.
 - Responsive variants of width utility classes are now enabled.
 
+### Improvements
+
+- Navbar link text is no longer uppercase.
+
 ## 6.1.0
 
 ### Improvements

--- a/src/scss/components/_navbar.scss
+++ b/src/scss/components/_navbar.scss
@@ -110,7 +110,6 @@ $header-height: 10;
       > .usa-nav__link {
         font-weight: normal;
         color: color('primary-dark');
-        text-transform: uppercase;
         @include u-padding-x(1.5);
 
         &:hover {


### PR DESCRIPTION
**Why**: Per Figma design system "Layouts and templates". This is already applied to the brochure site via [style override](https://github.com/18F/identity-site/blob/25d5b444c3b8852b5000721837e84aef75a92512/_sass/components/_nav.scss#L191), and reflected in upcoming Partnerships site design.

Before|After
---|---
![image](https://user-images.githubusercontent.com/1779930/132916266-35aea938-1755-4749-921c-5b6892b8cf7e.png)|![image](https://user-images.githubusercontent.com/1779930/132916278-ece17917-92e9-45c3-b17c-fadcbd1c09bd.png)

