### PR TITLE
Use default focus outline for unstyled buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Navbar link text is no longer uppercase. ([#249](https://github.com/18F/identity-style-guide/pull/249))
 - Visual alignment of Badge component is improved, and its markup guidance has been simplified with improved accessibility semantics. ([#251](https://github.com/18F/identity-style-guide/pull/251))
 - Field validation error messages now use updated styling to always display an icon as part of the error message, and not within the field itself. The modifier classes `usa-input--inline` and `usa-error-message--with-icon` no longer have any effect and can be safely removed. ([#255](https://github.com/18F/identity-style-guide/pull/255))
+- Focus styles for links and unstyled buttons are now the same. ([#253](https://github.com/18F/identity-style-guide/pull/253))
 
 ## 6.1.0
 

--- a/src/scss/components/_buttons.scss
+++ b/src/scss/components/_buttons.scss
@@ -24,19 +24,8 @@ $button-stroke-big: inset 0 0 0 units($theme-button-stroke-width * 2);
 
   &.usa-button:not([disabled]):focus,
   &.usa-button:not([disabled]).usa-focus {
+    @include focus-outline;
     box-shadow: none;
-
-    &::before {
-      border-radius: .125rem;
-      bottom: -5px;
-      box-shadow: 0 0 0 $theme-focus-width color($theme-focus-color);
-      content: '';
-      left: -5px;
-      pointer-events: none;
-      position: absolute;
-      right: -5px;
-      top: -5px;
-    }
   }
 }
 


### PR DESCRIPTION
Context: https://github.com/18F/identity-idp/pull/5394#issuecomment-918153858

**Why**: To maintain a consistent visual style between links and unstyled buttons.

Before|After
---|---
![image](https://user-images.githubusercontent.com/1779930/135162054-95bbb5bd-f3a2-41d2-9760-217239b8fca6.png)|![image](https://user-images.githubusercontent.com/1779930/135162025-993fad56-f607-459a-b087-1df4aaae7022.png)

Live preview URL: https://federalist-2f194a10-945e-4413-be01-46ca6dae5358.app.cloud.gov/preview/18f/identity-style-guide/aduth-unstyled-button-focus-outline/components/buttons/#unstyled