### PR TITLE
Configure auto-updates for USWDS

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    allow:
+      - dependency-name: 'uswds'


### PR DESCRIPTION
**Why**: To reduce confusion and maintenance overhead incurred by version drift, to simplify the sync process, and to take advantage of the latest features and bug fixes as quickly as they're made available.

Reference: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/enabling-and-disabling-version-updates#enabling-github-dependabot-version-updates