### PR TITLE
Update form validation error message styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Navbar link text is no longer uppercase.
 - Visual alignment of Badge component is improved, and its markup guidance has been simplified with improved accessibility semantics.
-- Field validation error messages now use updated styling to always display an icon as part of the error message, and not within the field itself. The modifier classes `usa-input--inline` and `usa-error-message--with-icon` no longer have any effect and can be safely removed.
+- Field validation error messages now use updated styling to always display an icon as part of the error message, and not within the field itself. The modifier classes `usa-input--inline` and `usa-error-message--with-icon` no longer have any effect and can be safely removed. ([#255](https://github.com/18F/identity-style-guide/pull/255))
 
 ## 6.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Navbar link text is no longer uppercase.
 - Visual alignment of Badge component is improved, and its markup guidance has been simplified with improved accessibility semantics.
+- Field validation error messages now use updated styling to always display an icon as part of the error message, and not within the field itself. The modifier classes `usa-input--inline` and `usa-error-message--with-icon` no longer have any effect and can be safely removed.
 
 ## 6.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,14 @@
 
 ### New Features
 
-- All theme variables are now set as [default values](https://sass-lang.com/documentation/variables#default-values), allowing you to override them for per-project requirements.
+- All theme variables are now set as [default values](https://sass-lang.com/documentation/variables#default-values), allowing you to override them for per-project requirements. ([#247](https://github.com/18F/identity-style-guide/pull/247))
   - Note: Since the design system is meant to be an opinionated set of smart defaults, it's recommended to use restraint with variable customization, or at least consider when it may be more appropriate to adjust a setting from the design system itself in order to maintain consistency across projects.
-- Responsive variants of width utility classes are now enabled.
+- Responsive variants of width utility classes are now enabled. ([#248](https://github.com/18F/identity-style-guide/pull/248))
 
 ### Improvements
 
-- Navbar link text is no longer uppercase.
-- Visual alignment of Badge component is improved, and its markup guidance has been simplified with improved accessibility semantics.
+- Navbar link text is no longer uppercase. ([#249](https://github.com/18F/identity-style-guide/pull/249))
+- Visual alignment of Badge component is improved, and its markup guidance has been simplified with improved accessibility semantics. ([#251](https://github.com/18F/identity-style-guide/pull/251))
 - Field validation error messages now use updated styling to always display an icon as part of the error message, and not within the field itself. The modifier classes `usa-input--inline` and `usa-error-message--with-icon` no longer have any effect and can be safely removed. ([#255](https://github.com/18F/identity-style-guide/pull/255))
 
 ## 6.1.0

--- a/docs/_components/form-fields.md
+++ b/docs/_components/form-fields.md
@@ -43,15 +43,15 @@ Three text fields are the easiest way for users to enter most dates.
   <div class="usa-memorable-date">
     <div class="usa-form-group usa-form-group--month">
       <label for="f5bf" class="usa-label">Month</label>
-      <input id="f5bf" class="usa-input usa-input--inline" aria-describedby="d7d4" type="text" maxlength="2" pattern="[0-9]*" inputmode="numeric">
+      <input id="f5bf" class="usa-input" aria-describedby="d7d4" type="text" maxlength="2" pattern="[0-9]*" inputmode="numeric">
     </div>
     <div class="usa-form-group usa-form-group--day">
       <label for="b0fe" class="usa-label">Day</label>
-      <input id="b0fe" class="usa-input usa-input--inline" aria-describedby="d7d4" type="text" maxlength="2" pattern="[0-9]*" inputmode="numeric">
+      <input id="b0fe" class="usa-input" aria-describedby="d7d4" type="text" maxlength="2" pattern="[0-9]*" inputmode="numeric">
     </div>
     <div class="usa-form-group usa-form-group--year">
       <label for="dc41" class="usa-label">Year</label>
-      <input id="dc41" class="usa-input usa-input--inline" aria-describedby="d7d4" type="text" minlength="4" maxlength="4" pattern="[0-9]*" inputmode="numeric">
+      <input id="dc41" class="usa-input" aria-describedby="d7d4" type="text" minlength="4" maxlength="4" pattern="[0-9]*" inputmode="numeric">
     </div>
   </div>
   <span class="usa-form-hint" id="d7d4">Example: 4 28 1986</span>
@@ -329,15 +329,15 @@ Follow the same pattern of applying `.usa-input--error` to the effected input an
   <div class="usa-memorable-date">
     <div class="usa-form-group usa-form-group--month">
       <label for="e30e" class="usa-label">Month</label>
-      <input id="e30e" class="usa-input usa-input--inline usa-input--error" aria-describedby="f9e5" type="text" maxlength="2" pattern="[0-9]*" inputmode="numeric">
+      <input id="e30e" class="usa-input usa-input--error" aria-describedby="f9e5" type="text" maxlength="2" pattern="[0-9]*" inputmode="numeric">
     </div>
     <div class="usa-form-group usa-form-group--day">
       <label for="b857" class="usa-label">Day</label>
-      <input id="b857" class="usa-input usa-input--inline usa-input--error" aria-describedby="f9e5" type="text" maxlength="2" pattern="[0-9]*" inputmode="numeric">
+      <input id="b857" class="usa-input usa-input--error" aria-describedby="f9e5" type="text" maxlength="2" pattern="[0-9]*" inputmode="numeric">
     </div>
     <div class="usa-form-group usa-form-group--year">
       <label for="a5dc" class="usa-label">Year</label>
-      <input id="a5dc" class="usa-input usa-input--inline usa-input--error" aria-describedby="f9e5" type="text" minlength="4" maxlength="4" pattern="[0-9]*" inputmode="numeric">
+      <input id="a5dc" class="usa-input usa-input--error" aria-describedby="f9e5" type="text" minlength="4" maxlength="4" pattern="[0-9]*" inputmode="numeric">
     </div>
   </div>
   <span class="usa-form-hint" id="f9e5">Example: 4 28 1986</span>

--- a/docs/_components/form-fields.md
+++ b/docs/_components/form-fields.md
@@ -290,7 +290,7 @@ a grid row.
 
 <label for="e9a4" class="usa-label">Text input validation example</label>
 <input id="e9a4" type="text" class="usa-input usa-input--error">
-<span class="usa-error-message" role="alert">Error message text.</span>
+<span class="usa-error-message" role="alert">Error message text</span>
 
 {% endcapture %}
 {% include helpers/code-example.html code=example %}
@@ -310,7 +310,7 @@ Follow the same pattern of applying `.usa-input--error` to the effected input an
 {% capture example %}
 <label for="a37c" class="usa-label">Textarea (multiline) input</label>
 <textarea id="a37c" type="text" class="usa-textarea usa-input--error"></textarea>
-<span class="usa-error-message" role="alert">Error message text.</span>
+<span class="usa-error-message" role="alert">Error message text</span>
 {% endcapture %}
 {% include helpers/code-example.html code=example %}
     </div>
@@ -341,7 +341,7 @@ Follow the same pattern of applying `.usa-input--error` to the effected input an
     </div>
   </div>
   <span class="usa-form-hint" id="f9e5">Example: 4 28 1986</span>
-  <span class="usa-error-message" role="alert">Error message text.</span>
+  <span class="usa-error-message" role="alert">Error message text</span>
 </fieldset>
 {% endcapture %}
 {% include helpers/code-example.html code=example %}
@@ -363,7 +363,7 @@ Follow the same pattern of applying `.usa-input--error` to the effected input an
   <option value="value2">Option B</option>
   <option value="value3">Option C</option>
 </select>
-<span class="usa-error-message" role="alert">Error message text.</span>
+<span class="usa-error-message" role="alert">Error message text</span>
 {% endcapture %}
 {% include helpers/code-example.html code=example %}
     </div>
@@ -400,7 +400,7 @@ For radio buttons and checkboxes, simply add an error message directly after the
     </li>
   </ul>
 </fieldset>
-<span class="usa-error-message usa-error-message--with-icon" role="alert">Error message text.</span>
+<span class="usa-error-message" role="alert">Error message text</span>
 {% endcapture %}
 {% include helpers/code-example.html code=example %}
     </div>
@@ -431,7 +431,7 @@ For radio buttons and checkboxes, simply add an error message directly after the
     </li>
   </ul>
 </fieldset>
-<span class="usa-error-message usa-error-message--with-icon" role="alert">Error message text.</span>
+<span class="usa-error-message" role="alert">Error message text</span>
 {% endcapture %}
 {% include helpers/code-example.html code=example %}
     </div>

--- a/src/scss/components/_inputs.scss
+++ b/src/scss/components/_inputs.scss
@@ -15,7 +15,7 @@ $input-select-margin-right: 1;
 
 .usa-input,
 .usa-textarea {
-  @include u-border($border-width, 'primary-light');
+  @include u-border-color('primary-light');
   font-weight: font-weight('bold');
   background-color: color('primary-lightest');
   border-radius: radius('md');
@@ -27,14 +27,7 @@ $input-select-margin-right: 1;
   }
 
   &.usa-input--error {
-    @include u-border($border-width, 'error');
-    background-position: right units($input-padding) center;
-    background-size: units($icon-size);
-
-    &:not(.usa-input--inline) {
-      @include add-background-svg('alerts/error');
-      padding-right: units(2 * $input-padding) + units($icon-size);
-    }
+    @include u-border-color('error');
   }
 }
 
@@ -47,7 +40,7 @@ $input-select-margin-right: 1;
 }
 
 .usa-select {
-  @include u-border($border-width, 'primary-light');
+  @include u-border-color('primary-light');
   @include add-background-svg('arrow-down-filled');
   font-weight: font-weight('bold');
   background-position: right .75rem center;
@@ -60,7 +53,7 @@ $input-select-margin-right: 1;
   }
 
   &.usa-input--error {
-    @include u-border($border-width, 'error');
+    @include u-border-color('error');
   }
 }
 
@@ -228,12 +221,9 @@ $input-select-margin-right: 1;
 }
 
 .usa-error-message {
+  @include add-background-svg('alerts/error');
+  background-position: 0 center;
+  background-size: units($icon-size);
   color: color('error');
-
-  &.usa-error-message--with-icon {
-    @include add-background-svg('alerts/error');
-    background-position: 0 center;
-    background-size: units($icon-size);
-    padding-left: units($icon-size * 1.5);
-  }
+  padding-left: units($icon-size * 1.5);
 }

--- a/src/scss/uswds-theme/_components.scss
+++ b/src/scss/uswds-theme/_components.scss
@@ -37,5 +37,6 @@ $theme-footer-font-family: 'body' !default;
 // Form and input
 $theme-checkbox-border-radius: 1.5px !default;
 $theme-input-line-height: 3 !default;
+$theme-input-state-border-width: 2px;
 $theme-input-tile-border-radius: 'lg' !default;
 $theme-input-tile-border-width: 1px !default;

--- a/test/dist/scss.test.js
+++ b/test/dist/scss.test.js
@@ -29,12 +29,8 @@ test('if an asset-path function is defined, it is used to generate asset paths w
   const css = results.css.toString('utf-8');
 
   const [usaAlertWarning] = css.match(/\.usa-alert--warning:before\s?{[^}]+}/);
-  const [usaInputError] = css.match(
-    /\.usa-textarea\.usa-input--error:not\(\.usa-input--inline\)\s?{[^}]+}/,
-  );
   const [fontFace] = css.match(/@font-face\s?{[^}]+}/);
 
   expect(usaAlertWarning).toMatch(/test-path-rewritten\/test-img/);
-  expect(usaInputError).toMatch(/test-path-rewritten\/test-img/);
   expect(fontFace).toMatch(/test-path-rewritten\/test-fonts/);
 }, 10000);


### PR DESCRIPTION
**Why**: As an end-user, if I try to submit a form with invalid form values, I want to see consistent and accessible messaging that tells me what I need to complete before I can submit the form successfully.

References:

- LG-4235
- https://gsa-tts.slack.com/archives/C01JVKYE4KD/p1632934852000500

Before|After
---|---
![image](https://user-images.githubusercontent.com/1779930/135321753-5f2cbf1f-ca90-40bd-81f1-ab4202c0f7f1.png)|![image](https://user-images.githubusercontent.com/1779930/135321792-3731f44a-5871-420f-99b8-619df95202c2.png)

Live preview URL: TBD