### PR TITLE
Backport additional search styles from brochure site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Form hint text is now shown with an italicized style and increased vertical margins. ([#262](https://github.com/18F/identity-style-guide/pull/262))
 - Icons for form validation errors are aligned to the top. ([#265](https://github.com/18F/identity-style-guide/pull/265))
 - The tile variant of checkboxes and radio buttons have a slightly increased font size. ([#281](https://github.com/18F/identity-style-guide/pull/281))
+- Search will now show full text labels at all sizes, and uses standardized font tokens. ([#259](https://github.com/18F/identity-style-guide/pull/259))
 
 ### Bug Fixes
 

--- a/docs/_components/search.md
+++ b/docs/_components/search.md
@@ -9,15 +9,16 @@ lead: >
   Search allows users to search for specific content if they know what search terms to use or can’t find desired content in the main navigation.
 ---
 
+{% include helpers/base-component.html component="search" %}
+
 ## Default
+
 Search should be easily found. For the default search version, consider displaying in the header and/or side navigation.
 
 {% capture example %}
-<form accept-charset="UTF-8" action="https://search.usa.gov/search" class="usa-search usa-search--smalldisplay-flex flex-justify-center tablet:grid-col-4" method="get" role="search">
-  <input name="utf8" type="hidden" value="&#x2713;"/>
-  <input name="affiliate" type="hidden" value="login.gov"/>
-  <label class="usa-sr-only" for="search-field-header-nav">Search</label>
-  <input class="usa-input" id="search-field-header-nav" name="query" type="search">
+<form class="usa-search" role="search">
+  <label class="usa-sr-only" for="tkBH">Search</label>
+  <input class="usa-input" id="tkBH" type="search">
   <button class="usa-button" type="submit">
     <span class="usa-search__submit-text">Search</span>
   </button>
@@ -26,14 +27,13 @@ Search should be easily found. For the default search version, consider displayi
 {% include helpers/code-example.html code=example %}
 
 ## Big variant
+
 If searching is a primary action of the site, consider adding the big variant version to the primary hero section to reinforce that action.
 
 {% capture example %}
-<form accept-charset="UTF-8" action="https://search.usa.gov/search" class="usa-search usa-search--big display-flex flex-justify-center" method="get" role="search">
-  <input name="utf8" type="hidden" value="&#x2713;"/>
-  <input name="affiliate" type="hidden" value="login.gov"/>
-  <label class="usa-sr-only" for="search-field-{{ include.id }}">Search</label>
-  <input class="usa-input" id="search-field-{{ include.id }}" name="query" type="search">
+<form class="usa-search usa-search--big" role="search">
+  <label class="usa-sr-only" for="V3Nn">Search</label>
+  <input class="usa-input" id="V3Nn" type="search">
   <button class="usa-button" type="submit">
     <span class="usa-search__submit-text">Search</span>
   </button>

--- a/src/scss/components/_search.scss
+++ b/src/scss/components/_search.scss
@@ -1,0 +1,19 @@
+.usa-search [type='submit'],
+.usa-search .usa-search__submit {
+  @include u-padding-x('105');
+  background-image: none;
+  font-size: font-size($theme-search-font-family, '2xs');
+  width: auto;
+}
+
+.usa-search .usa-search__submit-text {
+  position: static;
+}
+
+.usa-search--big [type='submit'],
+.usa-search--big .usa-search__submit {
+  @include at-media('mobile-lg') {
+    @include u-padding-x(4);
+    font-size: font-size($theme-search-font-family, 'lg');
+  }
+}

--- a/src/scss/packages/_components.scss
+++ b/src/scss/packages/_components.scss
@@ -21,6 +21,7 @@
 @import '../components/links';
 @import '../components/navbar';
 @import '../components/process-list';
+@import '../components/search';
 @import '../components/sidenav';
 @import '../components/spinner';
 @import '../components/typography';


### PR DESCRIPTION
- Full button text "Search" is always shown, regardless of viewport size
- Reduce padding for default search button from 2 units (1rem) to 1.5 units (0.75rem)
- Reduce font size for default search button from xs (1rem) to 2xs (0.87rem)

Live preview: https://federalist-2f194a10-945e-4413-be01-46ca6dae5358.app.cloud.gov/preview/18f/identity-style-guide/aduth-backport-more-search/components/search/