### PR TITLE
Build SASS synchronously

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -131,7 +131,7 @@ gulp.task('build-sass', () => {
   const stream = gulp
     .src([`${PROJECT_SASS_SRC}/*.scss`])
     .pipe(sourcemaps.init({ largeFile: true }))
-    .pipe(sass().on('error', notificationOptions.handler))
+    .pipe(sass.sync().on('error', notificationOptions.handler))
     .pipe(postcss(plugins))
     .pipe(gulp.dest(CSS_DEST))
     .pipe(notify(notificationOptions.success));


### PR DESCRIPTION
**Why**: Because it's much faster.

Reference: https://github.com/dlmanning/gulp-sass#usage

_Before:_

```
[09:28:52] Finished 'build-sass' after 44 s
```

_After:_

```
[09:43:04] Finished 'build-sass' after 16 s
```