### PR TITLE
Fix line wrapping for Buttons documentation

### DIFF
--- a/docs/_components/buttons.md
+++ b/docs/_components/buttons.md
@@ -21,11 +21,13 @@ subnav:
 <button class="usa-button">
 ```
 
-<button class="usa-button">Default</button>
-<button class="usa-button usa-button--hover">Hover</button>
-<button class="usa-button usa-button--active">Active</button>
-<button class="usa-button usa-focus">Focus</button>
-<button class="usa-button" disabled>Disabled</button>
+<div>
+  <button class="usa-button">Default</button>
+  <button class="usa-button usa-button--hover">Hover</button>
+  <button class="usa-button usa-button--active">Active</button>
+  <button class="usa-button usa-focus">Focus</button>
+  <button class="usa-button" disabled>Disabled</button>
+</div>
 
 ### Outline
 
@@ -33,11 +35,13 @@ subnav:
 <button class="usa-button usa-button--outline">
 ```
 
-<button class="usa-button usa-button--outline">Default</button>
-<button class="usa-button usa-button--outline usa-button--hover">Hover</button>
-<button class="usa-button usa-button--outline usa-button--active">Active</button>
-<button class="usa-button usa-button--outline usa-focus">Focus</button>
-<button class="usa-button usa-button--outline" disabled>Disabled</button>
+<div>
+  <button class="usa-button usa-button--outline">Default</button>
+  <button class="usa-button usa-button--outline usa-button--hover">Hover</button>
+  <button class="usa-button usa-button--outline usa-button--active">Active</button>
+  <button class="usa-button usa-button--outline usa-focus">Focus</button>
+  <button class="usa-button usa-button--outline" disabled>Disabled</button>
+</div>
 
 ### Danger
 
@@ -45,11 +49,13 @@ subnav:
 <button class="usa-button usa-button--danger">
 ```
 
-<button class="usa-button usa-button--danger">Default</button>
-<button class="usa-button usa-button--danger usa-button--hover">Hover</button>
-<button class="usa-button usa-button--danger usa-button--active">Active</button>
-<button class="usa-button usa-button--danger usa-focus">Focus</button>
-<button class="usa-button usa-button--danger" disabled>Disabled</button>
+<div>
+  <button class="usa-button usa-button--danger">Default</button>
+  <button class="usa-button usa-button--danger usa-button--hover">Hover</button>
+  <button class="usa-button usa-button--danger usa-button--active">Active</button>
+  <button class="usa-button usa-button--danger usa-focus">Focus</button>
+  <button class="usa-button usa-button--danger" disabled>Disabled</button>
+</div>
 
 ### Unstyled
 


### PR DESCRIPTION
**Why**: So that all of the button previews appear on the same line, and for consistency with how this is already handled for larger button variants.

By default, content in a Markdown file is rendered in paragraph elements within a `usa-prose` block which constrains the width of the content. This is a good thing for text content, since it helps limit line length. However, it doesn't make sense for component previews.

**Screenshots:**

Before|After
---|---
![image](https://user-images.githubusercontent.com/1779930/142282690-98a74f9e-06be-4fb5-a331-7a06b9c86de0.png)|![image](https://user-images.githubusercontent.com/1779930/142282695-44abeccd-4d03-4e8a-b0f3-25519eabba93.png)

Review with whitespace hidden: https://github.com/18F/identity-style-guide/pull/273/files?w=1