### PR TITLE
Fix Jekyll site URL assignment

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 title: Login.gov Design System
 description: A place for designers and developers to see components available for use on Login.gov sites.
 github_repo_url: https://github.com/18F/identity-style-guide
-url: https://federalist-proxy.app.cloud.gov/site/18f/identity-style-guide
+url: https://design.login.gov
 domain: design.login.gov
 
 source: docs

--- a/docs/_plugins/site_url.rb
+++ b/docs/_plugins/site_url.rb
@@ -1,7 +1,7 @@
 FEDERALIST_PREVIEW_BRANCH_PREFIX = '/preview/'
 
 Jekyll::Hooks.register :site, :after_init do |site|
-  if ENV['BRANCH'].nil?
+  if ENV['BRANCH'].nil? && ENV['JEKYLL_ENV'] != 'production'
     site.config['url'] = "http://localhost:#{site.config['port']}"
   elsif ENV['BASEURL']&.start_with?(FEDERALIST_PREVIEW_BRANCH_PREFIX)
     # We don't have enough information to reconstruct the URL for the preview site. Setting to `nil`

--- a/docs/_plugins/site_url.rb
+++ b/docs/_plugins/site_url.rb
@@ -1,0 +1,10 @@
+FEDERALIST_URL_BASE = 'https://federalist-proxy.app.cloud.gov/site'
+FEDERALIST_PREVIEW_BRANCH_PREFIX = '/preview/'
+
+Jekyll::Hooks.register :site, :after_init do |site|
+  if ENV['BRANCH'].nil?
+    site.config['url'] = "http://localhost:#{site.config['port']}"
+  elsif ENV['BASEURL']&.start_with?(FEDERALIST_PREVIEW_BRANCH_PREFIX)
+    site.config['url'] = "#{FEDERALIST_URL_BASE}/#{ENV['OWNER']}/#{ENV['REPOSITORY']}"
+  end
+end

--- a/docs/_plugins/site_url.rb
+++ b/docs/_plugins/site_url.rb
@@ -1,10 +1,12 @@
-FEDERALIST_URL_BASE = 'https://federalist-proxy.app.cloud.gov/site'
 FEDERALIST_PREVIEW_BRANCH_PREFIX = '/preview/'
 
 Jekyll::Hooks.register :site, :after_init do |site|
   if ENV['BRANCH'].nil?
     site.config['url'] = "http://localhost:#{site.config['port']}"
   elsif ENV['BASEURL']&.start_with?(FEDERALIST_PREVIEW_BRANCH_PREFIX)
-    site.config['url'] = "#{FEDERALIST_URL_BASE}/#{ENV['OWNER']}/#{ENV['REPOSITORY']}"
+    # We don't have enough information to reconstruct the URL for the preview site. Setting to `nil`
+    # at least allows redirects to work correctly. Sitemap URLs will be invalid, but since preview
+    # sites aren't intended to be indexed, this is tolerable.
+    site.config['url'] = nil
   end
 end

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,8 +53,7 @@
         "stylelint-scss": "^3.19.0",
         "vinyl-buffer": "^1.0.1",
         "vinyl-source-stream": "^2.0.0",
-        "wait-on": "^5.3.0",
-        "yaml": "^1.10.2"
+        "wait-on": "^5.3.0"
       },
       "engines": {
         "node": ">=12",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
     "stylelint-scss": "^3.19.0",
     "vinyl-buffer": "^1.0.1",
     "vinyl-source-stream": "^2.0.0",
-    "wait-on": "^5.3.0",
-    "yaml": "^1.10.2"
+    "wait-on": "^5.3.0"
   }
 }

--- a/scripts/pa11y.sh
+++ b/scripts/pa11y.sh
@@ -2,7 +2,8 @@
 
 set -o xtrace
 
-PRODUCTION_URL=$(grep '^url:' ./_config.yml | cut -d ' ' -f2)
+JEKYLL_PORT=$(grep '^port:' ./_config.yml | cut -d ' ' -f2)
+JEKYLL_PORT=${JEKYLL_PORT:-4000}
 PA11Y_PORT=$(./node_modules/.bin/get-port)
 RESULTS_DIRECTORY=./tmp/results/pa11y
 
@@ -16,7 +17,7 @@ mkdir -p $RESULTS_DIRECTORY
 
 ./node_modules/.bin/pa11y-ci \
   --sitemap http://0.0.0.0:$PA11Y_PORT/sitemap.xml \
-  --sitemap-find $PRODUCTION_URL \
+  --sitemap-find http://localhost:$JEKYLL_PORT \
   --sitemap-replace http://0.0.0.0:$PA11Y_PORT \
   --json > ${RESULTS_DIRECTORY}/results.json
 

--- a/test/screenshot.test.js
+++ b/test/screenshot.test.js
@@ -84,7 +84,7 @@ function fillImageToSize(image, width, height) {
 }
 
 test('screenshot visual regression', async () => {
-  const paths = (await getURLsFromSitemap(`${REMOTE_HOST}/sitemap.xml`)).map(getURLPath);
+  const paths = (await getURLsFromSitemap(`${LOCAL_HOST}/sitemap.xml`)).map(getURLPath);
 
   for (const path of paths) {
     const local = await getScreenshot(LOCAL_HOST + path);

--- a/test/screenshot.test.js
+++ b/test/screenshot.test.js
@@ -1,19 +1,17 @@
 /* eslint-disable no-restricted-syntax, no-await-in-loop, no-param-reassign */
 
-const { promises: fsPromises, readFileSync } = require('fs');
+const { promises: fsPromises } = require('fs');
 const { join } = require('path');
 const assert = require('assert');
 const mkdirp = require('mkdirp');
 const { PNG } = require('pngjs');
 const match = require('pixelmatch');
-const YAML = require('yaml');
 
 const { writeFile } = fsPromises;
 
 const LOCAL_HOST = `http://localhost:${process.env.JEST_PORT}`;
 const REMOTE_HOST = 'https://design.login.gov';
 const DIFF_DIRECTORY = join(__dirname, '../tmp/results/screenshot-diff');
-const { url: URL_PREFIX } = YAML.parse(readFileSync(join(__dirname, '../_config.yml'), 'utf8'));
 
 async function getURLsFromSitemap(url) {
   await page.goto(url);
@@ -51,9 +49,7 @@ async function getScreenshot(url) {
 }
 
 function getURLPath(url) {
-  const prefix = new URL(URL_PREFIX).pathname;
-  const { pathname } = new URL(url);
-  return pathname.indexOf(prefix) === 0 ? pathname.slice(prefix.length) : pathname;
+  return new URL(url).pathname;
 }
 
 function getDiffOutputBaseFileName(pathname) {


### PR DESCRIPTION
Inspired by: https://github.com/18F/handbook/pull/2928 ([relevant Slack discussion](https://gsa-tts.slack.com/archives/C1NUUGTT5/p1637088742004300), h/t @mgwalker )

This pull request attempts to improve the Jekyll `url` configuration to accommodate different combinations of...

- Build environments
   - Local development
   - Federalist preview sites
   - Federalist live site
- Jekyll plugins
   - `jekyll-redirect-from`
   - `jekyll-sitemap`

The current configuration has a few issues:

- It wrongly assigns Federalist URLs as values in the [live site sitemap.xml](https://design.login.gov/sitemap.xml)
- Sitemap URLs for preview sites are invalid ([example](https://federalist-2f194a10-945e-4413-be01-46ca6dae5358.app.cloud.gov/preview/18f/identity-style-guide/aduth-backport-more-search/sitemap.xml))
- `jekyll-redirect-from` redirects to the preview site in local development
   - Notably affecting the new "Components" top-level navigation redirect introduced in #270

The proposed changes seek to address this by configuring the live site as the default `url` value, then using a Jekyll plugin to override this based on environment:

- In Federalist preview branches, setting the `url` value to `nil`. As mentioned in the inline code comment, this is not ideal, but allows redirects to work correctly. It doesn't appear that we have enough information in the environment to be able to reconstruct Federalist preview URLs (such as the UUID of the `cloud.gov` subdomain).
- In local development, setting the `localhost` URL as the `url` value

This branch is temporarily based against `aduth-backport-mobile-nav` (#270) to check a few issues:

- Top-level "Components" navigation item still redirects correctly in all environments
- pa11y accessibility tests are fixed, swapping sitemap URLs appropriately (see `scripts/pa11y.sh`)