### PR TITLE
Match usa-input-error selector to USWDS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
 
 - Upgraded USWDS from v2.12.1 to v2.12.2 (see [release notes](https://github.com/uswds/uswds/releases/tag/v2.12.2)) ([#269](https://github.com/18F/identity-style-guide/pull/269))
 
+### Bug Fixes
+
+- Fix an issue where `.usa-input--error` would apply the incorrect border color unless also accompanied by `.usa-input`, `.usa-textarea`, or `.usa-select`. ([#275](https://github.com/18F/identity-style-guide/pull/275))
+
 ## 6.2.0
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,13 @@
 - Form hint text is now shown with an italicized style and increased vertical margins. ([#262](https://github.com/18F/identity-style-guide/pull/262))
 - Icons for form validation errors are aligned to the top ([#265](https://github.com/18F/identity-style-guide/pull/265))
 
-### Dependencies
-
-- Upgraded USWDS from v2.12.1 to v2.12.2 (see [release notes](https://github.com/uswds/uswds/releases/tag/v2.12.2)) ([#269](https://github.com/18F/identity-style-guide/pull/269))
-
 ### Bug Fixes
 
 - Fix an issue where `.usa-input--error` would apply the incorrect border color unless also accompanied by `.usa-input`, `.usa-textarea`, or `.usa-select`. ([#275](https://github.com/18F/identity-style-guide/pull/275))
+
+### Dependencies
+
+- Upgraded USWDS from v2.12.1 to v2.12.2 (see [release notes](https://github.com/uswds/uswds/releases/tag/v2.12.2)) ([#269](https://github.com/18F/identity-style-guide/pull/269))
 
 ## 6.2.0
 

--- a/src/scss/components/_inputs.scss
+++ b/src/scss/components/_inputs.scss
@@ -26,10 +26,10 @@ $input-select-margin-right: 1;
     @include disable-default-focus-styles;
     box-shadow: roundable-focus-outline-box-shadows();
   }
+}
 
-  &.usa-input--error {
-    @include u-border-color('error');
-  }
+.usa-input--error {
+  @include u-border-color('error');
 }
 
 [type='search'],


### PR DESCRIPTION
**Why**: The [error input style selector in USWDS](https://github.com/uswds/uswds/blob/eb84a497042aa85d79e8b5d2225a874c210bdb33/src/stylesheets/elements/form-controls/_text-input.scss#L11-L13) does not qualify as one of `.usa-input`, `.usa-textarea`, or `.usa-select`. In many cases, this makes little difference since the modifier would be applied to an element with one of those classes. However, this is not strictly required, and causes some [challenge in the IdP with SimpleForm compatibility](https://github.com/18F/identity-idp/pull/5626), where design system classes are not yet being applied (pending LG-3877). Furthermore, per updated guidance in #271, selectors with overriding styles should seek to precisely match the USWDS selector it is overriding.

Future work should seek to bring stylesheet files into closer alignment with USWDS files where these styles are defined (tracked in LG-5398). This would include moving styles from `src/scss/components/_inputs.scss` to `src/scss/elements/form-controls/_text-input.scss`.

**Screenshots:**

Before|After
---|---
![Screen Shot 2021-11-22 at 9 29 37 AM](https://user-images.githubusercontent.com/1779930/142880936-c2450b26-5969-41d0-a811-8f4573b0f771.png)|![Screen Shot 2021-11-22 at 9 29 43 AM](https://user-images.githubusercontent.com/1779930/142880925-e7dd3579-ec8a-48c8-ab95-32a9fa96baaf.png)