### PR TITLE
Set font-size of tile checkbox/radio to 1.125rem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
 - Overlay is now shown with a lighter backdrop color. ([#260](https://github.com/18F/identity-style-guide/pull/260))
 - Form Dropdown is now more visually consistent with other form fields. ([#263](https://github.com/18F/identity-style-guide/pull/260))
 - Form hint text is now shown with an italicized style and increased vertical margins. ([#262](https://github.com/18F/identity-style-guide/pull/262))
-- Icons for form validation errors are aligned to the top ([#265](https://github.com/18F/identity-style-guide/pull/265))
+- Icons for form validation errors are aligned to the top. ([#265](https://github.com/18F/identity-style-guide/pull/265))
+- The tile variant of checkboxes and radio buttons have a slightly increased font size. ([#281](https://github.com/18F/identity-style-guide/pull/281))
 
 ### Bug Fixes
 

--- a/src/scss/components/_inputs.scss
+++ b/src/scss/components/_inputs.scss
@@ -128,19 +128,19 @@ $input-select-margin-right: 1;
 
 .usa-checkbox__input--tile + .usa-checkbox__label,
 .usa-radio__input--tile + .usa-radio__label {
-  @include u-font-size($theme-form-font-family, 'md');
   @include u-text('primary', 'bold');
   @include u-display('block');
   @include u-padding(3);
   padding-left: units(3) + $checkbox-radio-size + $input-select-margin-right;
   border-color: color($theme-input-tile-border-color);
   max-width: units($theme-input-max-width);
+  font-size: 1.125rem;
 
   &::before {
     left: units(3);
     margin-top: divide(
-      line-height($theme-form-font-family, $theme-input-line-height) *
-        font-size($theme-form-font-family, 'md') - $checkbox-radio-size,
+      line-height($theme-form-font-family, $theme-input-line-height) * 1.125rem -
+        $checkbox-radio-size,
       2
     );
   }


### PR DESCRIPTION
**Why**: To avoid font-face-specific sizing from causing the label text from being too small relative to the accompanying description.

**Screenshots:**

Before|After
---|---
![before](https://user-images.githubusercontent.com/1779930/150425543-99e00414-8c1b-40e6-8d08-532cbf867b53.png)|![after](https://user-images.githubusercontent.com/1779930/150425590-cb313bb6-3bbe-4007-a845-eec631c70dad.png)

Live preview URL: TBD