### PR TITLE
Set checkbox/radio label line-height to match body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,13 @@
 - Add Login.gov-specific component configuration. ([#258])(https://github.com/18F/identity-style-guide/pull/258))
   - [Identifier component](https://designsystem.digital.gov/components/identifier/)
   - Link colors on dark backgrounds
+- The default line-height is now set to 1.5. This is not being considered a breaking change, as it is the new default guidance. To preserve existing font settings to allow more time to migrate, set `$$theme-body-line-height: 6`. ([#283](https://github.com/18F/identity-style-guide/pull/283))
 - Overlay is now shown with a lighter backdrop color. ([#260](https://github.com/18F/identity-style-guide/pull/260))
 - Form Dropdown is now more visually consistent with other form fields. ([#263](https://github.com/18F/identity-style-guide/pull/260))
 - Form hint text is now shown with an italicized style and increased vertical margins. ([#262](https://github.com/18F/identity-style-guide/pull/262))
 - Icons for form validation errors are aligned to the top. ([#265](https://github.com/18F/identity-style-guide/pull/265))
 - The tile variant of checkboxes and radio buttons have a slightly increased font size. ([#281](https://github.com/18F/identity-style-guide/pull/281))
+- Checkbox and radio labels which span multiple lines should now appear with a consistent line height relative to surrounding body copy. ([#283](https://github.com/18F/identity-style-guide/pull/283))
 
 ### Bug Fixes
 

--- a/src/scss/components/_inputs.scss
+++ b/src/scss/components/_inputs.scss
@@ -52,6 +52,7 @@ $input-select-margin-right: 1;
 
 .usa-radio__label,
 .usa-checkbox__label {
+  @include u-line-height($theme-form-font-family, $theme-body-line-height);
   display: inline-block;
   margin-bottom: units(1);
   padding-left: $checkbox-radio-size + units($input-select-margin-right);
@@ -63,7 +64,7 @@ $input-select-margin-right: 1;
     margin-left: 0;
     margin-right: 0;
     margin-top: divide(
-      line-height($theme-form-font-family, $theme-input-line-height) *
+      line-height($theme-form-font-family, $theme-body-line-height) *
         font-size($theme-form-font-family, $theme-body-font-size) - $checkbox-radio-size,
       2
     );

--- a/src/scss/uswds-theme/_typography.scss
+++ b/src/scss/uswds-theme/_typography.scss
@@ -161,6 +161,7 @@ none:    none
 
 // Body settings are the equivalent of setting the <body> element
 $theme-body-font-size: 'xs' !default;
+$theme-body-line-height: 4 !default;
 
 // Headings
 $theme-h1-font-size: 'xl' !default;


### PR DESCRIPTION
**Why**: So that multi-line checkbox or radio fields do not appear tighter relative to surrounding body copy.

Note: This also changes the default line-height, configured to match secure.login.gov (changes from 1.6 default to 1.5).

Before|After
---|---
![before](https://user-images.githubusercontent.com/1779930/150855181-e0c98d24-e1c3-4cb0-87dc-701f4a68408b.png)|![after](https://user-images.githubusercontent.com/1779930/150855199-f9bb3102-10fe-4db5-be5a-3268c2ac1946.png)


