### PR TITLE
Improve vertical spacing in heading of Process List item spanning multiple lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 6.3.1
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Bug Fixes
+
+- Improve vertical spacing in heading of Process List item spanning multiple lines. ([#288](https://github.com/18F/identity-style-guide/pull/288))
+
 ## 6.3.0
 
 ### New Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "identity-style-guide",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "identity-style-guide",
-      "version": "6.3.0",
+      "version": "6.3.1",
       "license": "CC0-1.0",
       "dependencies": {
         "domready": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "identity-style-guide",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "description": "The global style of Login.gov",
   "main": "./build/cjs/index.js",
   "module": "./build/esm/index.js",

--- a/src/scss/components/_process-list.scss
+++ b/src/scss/components/_process-list.scss
@@ -14,11 +14,15 @@
   border-left-width: 0.3125rem;
 
   &::before {
-    margin-top: #{(units($theme-process-list-counter-size) - (1.125rem * lh('heading', 2))) * -0.5};
+    margin-top: #{(
+        units($theme-process-list-counter-size) -
+          (1.125rem * lh('heading', $theme-heading-line-height))
+      ) * -0.5};
   }
 }
 
 .usa-process-list__heading {
+  @include u-line-height('heading', $theme-heading-line-height);
   font-size: 1.125rem;
 
   & + * {
@@ -34,7 +38,7 @@
     border-left-width: units(1);
 
     &::before {
-      margin-top: #{(3.125rem - (1.125rem * lh('heading', 2))) * -0.5};
+      margin-top: #{(3.125rem - (1.125rem * lh('heading', $theme-heading-line-height))) * -0.5};
       width: 3.125rem;
       height: 3.125rem;
       font-size: units(3);


### PR DESCRIPTION
**Why**: So that headings do not appear excessively tight when spanning multiple lines.

This uses the theme-configured heading line-height variable (`$theme-heading-line-height`), replacing the hard-coded value of `2` from USWDS, which would previously result in a line-height of 1.1.

Live preview: https://federalist-2f194a10-945e-4413-be01-46ca6dae5358.app.cloud.gov/preview/18f/identity-style-guide/aduth-process-list-line-height/components/process-list/

**Screenshots:**

These are in context of the implementation of https://github.com/18F/identity-idp/pull/5863.

Before|After
---|---
![Screen Shot 2022-01-31 at 10 10 40 AM](https://user-images.githubusercontent.com/1779930/151819366-ef2c5862-0beb-462e-a621-ddab181ed440.png)|![Screen Shot 2022-01-31 at 10 10 23 AM](https://user-images.githubusercontent.com/1779930/151819381-734da8aa-a21d-4e16-a204-0126080c3047.png)