### PR TITLE
Remove vertical padding from Process List component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Improvements
+
+- The Process List component no longer applies vertical padding which would affect its layout relative to surrounding content. ([#290](https://github.com/18F/identity-style-guide/pull/290))
+
 ## 6.3.1
 
 ### Bug Fixes

--- a/src/scss/components/_process-list.scss
+++ b/src/scss/components/_process-list.scss
@@ -1,23 +1,37 @@
-.usa-process-list,
-.usa-prose .usa-process-list {
-  padding-left: (units($theme-process-list-counter-size) * 0.5) - (0.3125rem * 0.5);
-}
+$theme-process-list-counter-size-big: 3.125rem;
 
-.usa-process-list:not(.usa-process-list--connected) .usa-process-list__item,
-.usa-prose .usa-process-list:not(.usa-process-list--connected) .usa-process-list__item {
-  border-left-width: 0;
-}
+@include override-prose {
+  .usa-process-list {
+    padding-top: 0;
+    padding-left: (units($theme-process-list-counter-size) * 0.5) - (0.3125rem * 0.5);
 
-.usa-process-list__item,
-.usa-prose .usa-process-list__item {
-  padding-left: units(2) + (units($theme-process-list-counter-size) * 0.5) - (0.3125rem * 0.5);
-  border-left-width: 0.3125rem;
+    &:not(.usa-process-list--connected) .usa-process-list__item {
+      border-left-width: 0;
+    }
 
-  &::before {
-    margin-top: #{(
-        units($theme-process-list-counter-size) -
-          (1.125rem * lh('heading', $theme-heading-line-height))
-      ) * -0.5};
+    &.usa-process-list--big {
+      padding-top: 0.5 *
+        (
+          $theme-process-list-counter-size-big -
+            (1.125rem * lh('heading', $theme-heading-line-height))
+        );
+    }
+  }
+
+  .usa-process-list__item {
+    padding-left: units(2) + (units($theme-process-list-counter-size) * 0.5) - (0.3125rem * 0.5);
+    border-left-width: 0.3125rem;
+
+    &::before {
+      margin-top: #{(
+          units($theme-process-list-counter-size) -
+            (1.125rem * lh('heading', $theme-heading-line-height))
+        ) * -0.5};
+    }
+
+    &:last-child {
+      padding-bottom: 0;
+    }
   }
 }
 
@@ -38,9 +52,12 @@
     border-left-width: units(1);
 
     &::before {
-      margin-top: #{(3.125rem - (1.125rem * lh('heading', $theme-heading-line-height))) * -0.5};
-      width: 3.125rem;
-      height: 3.125rem;
+      margin-top: #{(
+          $theme-process-list-counter-size-big -
+            (1.125rem * lh('heading', $theme-heading-line-height))
+        ) * -0.5};
+      width: $theme-process-list-counter-size-big;
+      height: $theme-process-list-counter-size-big;
       font-size: units(3);
     }
   }


### PR DESCRIPTION
**Why**: The Process List component includes some top and bottom padding inherited from USWDS, making it difficult to position in content, where surrounding content's own margins may cause excess space. Most components don't (and shouldn't) include any inherent vertical spacing, allowing the developer to decide to apply margins as appropriate, or rely on margins from surrounding content. Margins also have the added benefit of allowing for [margin collapse](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing) behavior, to allow the component to be more easily reused in content without awareness of the specific context of its surrounding content.

Related discussion: https://github.com/18F/identity-idp/pull/5863#issuecomment-1028374791

Live preview URL: https://federalist-2f194a10-945e-4413-be01-46ca6dae5358.app.cloud.gov/preview/18f/identity-style-guide/aduth-rm-process-list-padding/components/process-list/

**Implementation notes:**

Since the "Big" variant circle can otherwise appear outside of the bounds of the Process List if no padding were applied, this implementation includes enough padding that the Process List bounds begin at the far extent of the first item's circle:

![image](https://user-images.githubusercontent.com/1779930/152548276-85bec8b6-5581-4235-bca0-33d4f5aeb4f0.png)

This padding does not exist for the default size, since the circle should appear at an identical size to the heading text:

![image](https://user-images.githubusercontent.com/1779930/152548428-2b3d858e-1386-49cf-a14d-17c016e85421.png)
