### PR TITLE
Change body font size to USWDS default "sm"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ### Improvements
 
-- Line height calculations are improved such that the [desired token size](https://github.com/uswds/uswds/blob/61a0d99f0e6b36c3758948ba6ac46140abc5e585/src/stylesheets/theme/_uswds-theme-typography.scss#L363-L371) will always apply regardless of font family or scale.
+- Line height calculations are improved such that the [desired token size](https://github.com/uswds/uswds/blob/61a0d99f0e6b36c3758948ba6ac46140abc5e585/src/stylesheets/theme/_uswds-theme-typography.scss#L363-L371) will always apply regardless of font family or scale. ([#291](https://github.com/18F/identity-style-guide/pull/291))
    - In the case of headings, line-height will fall back to the configured body line-height if the resulting actual line-height would be smaller than body content when using the heading scale.
+- Body font size has been increased slightly to restore an effective font size of 1rem. ([#292](https://github.com/18F/identity-style-guide/pull/292))
 - The Process List component no longer applies vertical padding which would affect its layout relative to surrounding content. ([#290](https://github.com/18F/identity-style-guide/pull/290))
 
 ## 6.3.1

--- a/src/scss/uswds-theme/_typography.scss
+++ b/src/scss/uswds-theme/_typography.scss
@@ -160,7 +160,6 @@ none:    none
 */
 
 // Body settings are the equivalent of setting the <body> element
-$theme-body-font-size: 'xs' !default;
 $theme-body-line-height: 4 !default;
 
 // Headings


### PR DESCRIPTION
Related Slack discussion: https://gsa-tts.slack.com/archives/CNCGEHG1G/p1644337817896069?thread_ts=1644246272.507329&cid=CNCGEHG1G

**Why**: Previously with Source Sans, a body font size of "xs" would result in an effective font size of 1rem, due to scaling resulting from its [smaller cap height](https://github.com/uswds/uswds/blob/61a0d99f0e6b36c3758948ba6ac46140abc5e585/src/stylesheets/core/_system-tokens.scss#L282) relative to the [base cap height](https://github.com/uswds/uswds/blob/61a0d99f0e6b36c3758948ba6ac46140abc5e585/src/stylesheets/core/_system-tokens.scss#L416). In Public Sans, "xs" results in an effective font size of 0.94rem. To restore the desired 1rem body font size, we should drop this override and inherit the USWDS default "sm".

Live preview URL: https://federalist-2f194a10-945e-4413-be01-46ca6dae5358.app.cloud.gov/preview/18f/identity-style-guide/aduth-default-font-size/utilities/typography/