### PR TITLE
update radio image width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Bug Fixes
+
+- Changing the radio tile image size from 1rem to 1.5rem. ([#299](https://github.com/18F/identity-style-guide/pull/299))
+
 ## 6.3.2
 
 ### Improvements

--- a/src/scss/components/_inputs.scss
+++ b/src/scss/components/_inputs.scss
@@ -157,7 +157,7 @@ $input-select-margin-right: 1;
 
   .usa-radio__image,
   .usa-checkbox__image {
-    width: 1rem;
+    width: 1.5rem;
     float: left;
     margin-right: 0.5rem;
     @include at-media('tablet') {


### PR DESCRIPTION
## Why
In order to have the correct sizing of svg icons (24px) for the illustrated ratio inputs, we need to update the width from 1 to 1.5 rem.