### PR TITLE
Remove redundant body background color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Optimization
 
 - Remove documentation-specific images from published package. ([#300](https://github.com/18F/identity-style-guide/pull/300))
+- Remove duplicate styles. ([#301](https://github.com/18F/identity-style-guide/pull/301))
 
 ## 6.3.3
 

--- a/src/scss/components/_general.scss
+++ b/src/scss/components/_general.scss
@@ -2,7 +2,3 @@
 html {
   background-color: color('primary-darker');
 }
-
-body {
-  background-color: color('white');
-}


### PR DESCRIPTION
**Why**: Because it's already set through USWDS.

See: https://github.com/uswds/uswds/blob/86636ea/src/stylesheets/settings/_settings-color.scss#L136

Before|After
---|---
![Screen Shot 2022-02-24 at 9 09 39 AM](https://user-images.githubusercontent.com/1779930/155540028-aebb58f5-45e9-483d-a287-24d7a920e6e5.png)|![Screen Shot 2022-02-24 at 9 10 31 AM](https://user-images.githubusercontent.com/1779930/155540040-6bd7bca3-6be7-424b-9047-f1db33cdc84b.png)

