### PR TITLE
Reconcile focus styles with USWDS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Remove documentation-specific images from published package. ([#300](https://github.com/18F/identity-style-guide/pull/300))
 - Remove duplicate styles. ([#301](https://github.com/18F/identity-style-guide/pull/301))
+- Reconcile redundant focus styles with U.S. Web Design System. ([#302](https://github.com/18F/identity-style-guide/pull/302))
 
 ## 6.3.3
 

--- a/src/scss/components/_buttons.scss
+++ b/src/scss/components/_buttons.scss
@@ -5,8 +5,7 @@ $button-stroke-big: inset 0 0 0 units($theme-button-stroke-width * 2);
 
   &:not([disabled]):focus,
   &:not([disabled]).usa-focus {
-    @include disable-default-focus-styles;
-    box-shadow: roundable-focus-outline-box-shadows();
+    outline-offset: units($theme-focus-offset);
   }
 }
 
@@ -20,28 +19,15 @@ $button-stroke-big: inset 0 0 0 units($theme-button-stroke-width * 2);
   // In USWDS, unstyled button styles are applied last to take precedence over base button styles.
   // Since we override base button styles, we must re-apply the unstyled button styles.
   @include button-unstyled;
-  position: relative;
-
-  &.usa-button:not([disabled]):focus,
-  &.usa-button:not([disabled]).usa-focus {
-    @include focus-outline;
-    box-shadow: none;
-  }
 }
 
 .usa-button--secondary,
 .usa-button--outline {
   background-color: color('white');
-  box-shadow: $button-stroke color('primary');
   color: color('primary');
 
   &:visited {
     color: color('primary');
-  }
-
-  &:not([disabled]):focus,
-  &:not([disabled]).usa-focus {
-    box-shadow: $button-stroke color('primary'), roundable-focus-outline-box-shadows();
   }
 
   &:hover,
@@ -57,46 +43,7 @@ $button-stroke-big: inset 0 0 0 units($theme-button-stroke-width * 2);
   &:disabled,
   &.usa-button--disabled {
     background-color: color('white');
-    box-shadow: $button-stroke color('disabled');
     color: color('disabled');
-  }
-
-  &.usa-button--big {
-    box-shadow: $button-stroke-big color('primary');
-
-    &:not([disabled]):focus,
-    &:not([disabled]).usa-focus {
-      box-shadow: $button-stroke-big color('primary'), roundable-focus-outline-box-shadows();
-    }
-
-    &:hover,
-    &.usa-button--hover {
-      box-shadow: $button-stroke-big color('primary-dark');
-    }
-
-    &:active,
-    &.usa-button--active {
-      box-shadow: $button-stroke-big color('primary-darker');
-    }
-
-    &:disabled,
-    &.usa-button--disabled {
-      box-shadow: $button-stroke-big color('disabled');
-    }
-
-    &.usa-button--inverse {
-      box-shadow: $button-stroke-big color('base-lighter');
-
-      &:hover,
-      &.usa-button--hover {
-        box-shadow: $button-stroke-big color($theme-link-reverse-hover-color);
-      }
-
-      &:active,
-      &.usa-button--active {
-        box-shadow: $button-stroke-big color($theme-link-reverse-active-color);
-      }
-    }
   }
 }
 

--- a/src/scss/components/_buttons.scss
+++ b/src/scss/components/_buttons.scss
@@ -45,6 +45,39 @@ $button-stroke-big: inset 0 0 0 units($theme-button-stroke-width * 2);
     background-color: color('white');
     color: color('disabled');
   }
+
+  &.usa-button--big {
+    box-shadow: $button-stroke-big color('primary');
+
+    &:hover,
+    &.usa-button--hover {
+      box-shadow: $button-stroke-big color('primary-dark');
+    }
+
+    &:active,
+    &.usa-button--active {
+      box-shadow: $button-stroke-big color('primary-darker');
+    }
+
+    &:disabled,
+    &.usa-button--disabled {
+      box-shadow: $button-stroke-big color('disabled');
+    }
+
+    &.usa-button--inverse {
+      box-shadow: $button-stroke-big color('base-lighter');
+
+      &:hover,
+      &.usa-button--hover {
+        box-shadow: $button-stroke-big color($theme-link-reverse-hover-color);
+      }
+
+      &:active,
+      &.usa-button--active {
+        box-shadow: $button-stroke-big color($theme-link-reverse-active-color);
+      }
+    }
+  }
 }
 
 .usa-button--danger {

--- a/src/scss/components/_inputs.scss
+++ b/src/scss/components/_inputs.scss
@@ -20,12 +20,6 @@ $input-select-margin-right: 1;
   font-weight: font-weight('bold');
   background-color: color('primary-lightest');
   border-radius: radius('md');
-
-  &.usa-focus,
-  &:focus {
-    @include disable-default-focus-styles;
-    box-shadow: roundable-focus-outline-box-shadows();
-  }
 }
 
 .usa-input--error {
@@ -104,27 +98,22 @@ $input-select-margin-right: 1;
 
 .usa-radio__input.usa-focus + .usa-radio__label::before,
 .usa-radio__input:focus + .usa-radio__label::before {
-  @include disable-default-focus-styles;
-  box-shadow: inset 0 0 0 units($border-width) color('primary'),
-    roundable-focus-outline-box-shadows();
+  @include focus-outline();
 }
 
 .usa-radio__input:checked.usa-focus + .usa-radio__label::before,
 .usa-radio__input:checked:focus + .usa-radio__label::before {
-  @include disable-default-focus-styles;
-  box-shadow: inset 0 0 0 3px color('primary'), roundable-focus-outline-box-shadows();
+  @include focus-outline();
 }
 
 .usa-checkbox__input.usa-focus + .usa-checkbox__label::before,
 .usa-checkbox__input:focus + .usa-checkbox__label::before {
-  @include disable-default-focus-styles;
-  box-shadow: inset 0 0 0 units($border-width) color('primary'),
-    roundable-focus-outline-box-shadows();
+  @include focus-outline();
 }
 
 .usa-checkbox__input:checked.usa-focus + .usa-checkbox__label::before,
 .usa-checkbox__input:checked:focus + .usa-checkbox__label::before {
-  box-shadow: roundable-focus-outline-box-shadows();
+  @include focus-outline();
 }
 
 .usa-checkbox__input--tile + .usa-checkbox__label,

--- a/src/scss/functions/_focus.scss
+++ b/src/scss/functions/_focus.scss
@@ -1,8 +1,0 @@
-@mixin disable-default-focus-styles {
-  outline: none;
-}
-
-@function roundable-focus-outline-box-shadows() {
-  @return 0 0 0 $theme-focus-offset color('white'),
-    0 0 0 $theme-focus-width + $theme-focus-offset color($theme-focus-color);
-}

--- a/src/scss/packages/_required.scss
+++ b/src/scss/packages/_required.scss
@@ -21,6 +21,5 @@
 @import '../uswds/core/deprecated';
 @import '../uswds/core/notifications';
 @import '../functions/asset-path';
-@import '../functions/focus';
 @import '../uswds/utilities/palettes/all';
 @import '../uswds/utilities/rules/all';


### PR DESCRIPTION
**Why**: To reduce the amount of generated styles for controlling focus appearance of fields, and to avoid error-prone reimplementation of focus styles by leveraging default styles and only overriding as needed.

Ideally there should be no visual changes associated with these revisions, which should be covered decently well with visual regression tests, as both buttons and radio/checkbox fields are documented with a full set of states.