### PR TITLE
Remove documentation styles from stylesheets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Remove documentation-specific images from published package. ([#300](https://github.com/18F/identity-style-guide/pull/300))
 - Remove duplicate styles. ([#301](https://github.com/18F/identity-style-guide/pull/301))
 - Reconcile redundant focus styles with U.S. Web Design System. ([#302](https://github.com/18F/identity-style-guide/pull/302))
+- Remove documentation site styles from design system artifact. ([#305](https://github.com/18F/identity-style-guide/pull/305))
 
 ### Dependencies
 

--- a/docs/_layouts/main.html
+++ b/docs/_layouts/main.html
@@ -8,11 +8,11 @@ layout: base
 
 {% assign sidenav = site.data.nav[page.sidenav] | default: page.sidenav %}
 
-<main class="usa-layout-docs usa-section" id="main-content">
+<main class="usa-section" id="main-content">
   <div class="grid-container">
     {% if sidenav %}
       <div class="grid-row grid-gap">
-        <aside class="usa-layout-docs__sidenav desktop:grid-col-3">
+        <aside class="desktop:grid-col-3">
           <nav>
             <ul class="usa-sidenav">
               {%
@@ -25,7 +25,7 @@ layout: base
           </nav>
         </aside>
 
-        <div class="usa-layout-docs__main desktop:grid-col-9 usa-prose">
+        <div class="desktop:grid-col-9 usa-prose">
           <h1>{{ page.title }}</h1>
 
           {% if page.lead %}
@@ -36,7 +36,7 @@ layout: base
         </div>
       </div>
     {% else %}
-      <div class="usa-layout-docs__main usa-prose">
+      <div class="usa-prose">
         <h1 class="usa-display">{{ page.title }}</h1>
 
         {% if page.lead %}

--- a/docs/_layouts/main.html
+++ b/docs/_layouts/main.html
@@ -8,11 +8,11 @@ layout: base
 
 {% assign sidenav = site.data.nav[page.sidenav] | default: page.sidenav %}
 
-<main class="usa-section" id="main-content">
+<main class="usa-layout-docs usa-section" id="main-content">
   <div class="grid-container">
     {% if sidenav %}
       <div class="grid-row grid-gap">
-        <aside class="desktop:grid-col-3">
+        <aside class="usa-layout-docs__sidenav desktop:grid-col-3">
           <nav>
             <ul class="usa-sidenav">
               {%
@@ -25,7 +25,7 @@ layout: base
           </nav>
         </aside>
 
-        <div class="desktop:grid-col-9 usa-prose">
+        <div class="usa-layout-docs__main desktop:grid-col-9 usa-prose">
           <h1>{{ page.title }}</h1>
 
           {% if page.lead %}
@@ -36,7 +36,7 @@ layout: base
         </div>
       </div>
     {% else %}
-      <div class="usa-prose">
+      <div class="usa-layout-docs__main usa-prose">
         <h1 class="usa-display">{{ page.title }}</h1>
 
         {% if page.lead %}

--- a/src/scss/components/_typography.scss
+++ b/src/scss/components/_typography.scss
@@ -57,22 +57,6 @@
   }
 }
 
-.usa-layout-docs__sidenav + .usa-layout-docs__main.usa-prose > {
-  h1 {
-    @include typeset-h1;
-
-    + * {
-      margin-top: 0.5em;
-    }
-  }
-}
-
-.usa-layout-docs__main.usa-prose > {
-  h1 {
-    @include typeset-display;
-  }
-}
-
 .usa-intro {
   @include u-font-size('sans', 'md');
 


### PR DESCRIPTION
**Why**: So that the design system artifact includes only styles which apply across projects.

In practice, this seems to only have the minor effect of altering the margin between documentation page heading and the subsequent paragraph (0.4rem to 0.5rem, or 0.5rem to 1rem), which does not seem worthwhile to maintain.

It's expected that visual regression tests would fail, and demonstrate the visual difference.