### PR TITLE
Prepare 6.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 6.4.0
 
 ### Deprecation Notice
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - The `alerts/success-badge.svg` image will be removed in a future major version. Use `alerts/success.svg` instead. ([#306](https://github.com/18F/identity-style-guide/pull/306))
 
+### Improvements
+
+- Improve appearance of illustrated tile checkboxes and radiob uttons. ([#309](https://github.com/18F/identity-style-guide/pull/309))
+
 ### Bug Fixes
 
 - Use correct "Success" green color for `alerts/unphishable.svg` icon. ([#306](https://github.com/18F/identity-style-guide/pull/306))
@@ -20,10 +24,6 @@
 
 - Update USWDS from v2.13.1 to 2.13.2. ([#304](https://github.com/18F/identity-style-guide/pull/304))
 - Update dependencies to resolve vulnerability advisories. ([#308](https://github.com/18F/identity-style-guide/pull/308))
-
-### Improvements
-
-- Incorporate mfa icon styles, which were previously added to the identity-idp. ([#309](https://github.com/18F/identity-style-guide/pull/309))
 
 ## 6.3.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Improvements
 
-- Improve appearance of illustrated tile checkboxes and radiob uttons. ([#309](https://github.com/18F/identity-style-guide/pull/309))
+- Improve appearance of illustrated tile checkboxes and radio buttons. ([#309](https://github.com/18F/identity-style-guide/pull/309))
 
 ### Bug Fixes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "identity-style-guide",
-  "version": "6.3.3",
+  "version": "6.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "identity-style-guide",
-      "version": "6.3.3",
+      "version": "6.4.0",
       "license": "CC0-1.0",
       "dependencies": {
         "domready": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "identity-style-guide",
-  "version": "6.3.3",
+  "version": "6.4.0",
   "description": "The global style of Login.gov",
   "main": "./build/cjs/index.js",
   "module": "./build/esm/index.js",


### PR DESCRIPTION
Following release process: https://github.com/18F/identity-style-guide#releases

Changelog: 

>## 6.4.0
>
>### Deprecation Notice
>
>- The `alerts/success-badge.svg` image will be removed in a future major version. Use `alerts/success.svg` instead. ([#306](https://github.com/18F/identity-style-guide/pull/306))
>
>### Improvements
>
>- Improve appearance of illustrated tile checkboxes and radio buttons. ([#309](https://github.com/18F/identity-style-guide/pull/309))
>
>### Bug Fixes
>
>- Use correct "Success" green color for `alerts/unphishable.svg` icon. ([#306](https://github.com/18F/identity-style-guide/pull/306))
>
>### Optimization
>- Remove documentation-specific images from published package. ([#300](https://github.com/18F/identity-style-guide/pull/300))
>- Remove duplicate styles. ([#301](https://github.com/18F/identity-style-guide/pull/301))
>- Reconcile redundant focus styles with U.S. Web Design System. ([#302](https://github.com/18F/identity-style-guide/pull/302))
>- Remove documentation site styles from design system artifact. ([#305](https://github.com/18F/identity-style-guide/pull/305))
>- Reduce size of SVG images. ([#307](https://github.com/18F/identity-style-guide/pull/307))
>
>### Dependencies
>- Update USWDS from v2.13.1 to 2.13.2. ([#304](https://github.com/18F/identity-style-guide/pull/304))
>- Update dependencies to resolve vulnerability advisories. ([#308](https://github.com/18F/identity-style-guide/pull/308))