### PR TITLE
Fix hidden search submit button text on small viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 6.4.1
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Bug Fixes
+
+- Fix an issue where search field submit buttons would not show text at small viewport sizes. ([#311](https://github.com/18F/identity-style-guide/pull/311))
+
 ## 6.4.0
 
 ### Deprecation Notice

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "identity-style-guide",
-  "version": "6.4.0",
+  "version": "6.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "identity-style-guide",
-      "version": "6.4.0",
+      "version": "6.4.1",
       "license": "CC0-1.0",
       "dependencies": {
         "domready": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "identity-style-guide",
-  "version": "6.4.0",
+  "version": "6.4.1",
   "description": "The global style of Login.gov",
   "main": "./build/cjs/index.js",
   "module": "./build/esm/index.js",

--- a/src/scss/components/_search.scss
+++ b/src/scss/components/_search.scss
@@ -6,8 +6,8 @@
   width: auto;
 }
 
-.usa-search .usa-search__submit-text {
-  position: static;
+.usa-search__submit-text {
+  display: block;
 }
 
 .usa-search--big [type='submit'],


### PR DESCRIPTION
Fixes regression of #259

**Why**: Because the submit button should have a visible text label.

Slack context: https://gsa-tts.slack.com/archives/C01710KMYUB/p1649431326074669

Live preview URL: https://federalist-2f194a10-945e-4413-be01-46ca6dae5358.app.cloud.gov/preview/18f/identity-style-guide/aduth-fix-hidden-search-text/components/search/

**Screenshots:**

Before|After
---|---
![image](https://user-images.githubusercontent.com/1779930/162474987-f7c98d4a-5094-4e0f-a530-b8a8ca9b9e89.png)|![image](https://user-images.githubusercontent.com/1779930/162475003-4e4616c8-eb64-4b4e-9a20-5669e99ed654.png)
