### PR TITLE
Prepare Release 6.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 6.4.2
 
 ### Dependencies
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "identity-style-guide",
       "version": "6.4.2",
       "license": "CC0-1.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "identity-style-guide",
       "version": "6.4.2",
       "license": "CC0-1.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "identity-style-guide",
-  "version": "6.4.1",
+  "version": "6.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "identity-style-guide",
-      "version": "6.4.1",
+      "version": "6.4.2",
       "license": "CC0-1.0",
       "dependencies": {
         "domready": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "identity-style-guide",
-  "version": "6.4.1",
+  "version": "6.4.2",
   "description": "The global style of Login.gov",
   "main": "./build/cjs/index.js",
   "module": "./build/esm/index.js",


### PR DESCRIPTION
Following release process: https://github.com/18F/identity-style-guide#releases

Changelog: 
> ## 6.4.2
> 
> ### Dependencies
> 
> - Update USWDS from v2.13.2 to 2.13.3. ([#312](https://github.com/18F/identity-style-guide/pull/312))
> 
> ### Improvements
> 
> - Add styles and markdown content for selected and disabled radios and checkboxes. ([#313](https://github.com/18F/identity-style-guide/pull/313))