### PR TITLE
Prepare 6.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 6.5.0
 
 ### Improvements
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "identity-style-guide",
-  "version": "6.4.2",
+  "version": "6.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "identity-style-guide",
-      "version": "6.4.2",
+      "version": "6.5.0",
       "license": "CC0-1.0",
       "dependencies": {
         "domready": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "identity-style-guide",
-  "version": "6.4.2",
+  "version": "6.5.0",
   "description": "The global style of Login.gov",
   "main": "./build/cjs/index.js",
   "module": "./build/esm/index.js",


### PR DESCRIPTION
Following release process: https://github.com/18F/identity-style-guide#releases

Changelog: 

>## 6.5.0
>
>### Improvements
>
>- Increase line-height for accordion heading content to improve readability. ([#316](https://github.com/18F/identity-style-guide/pull/316))