### PR TITLE
Add redirect for /components/ path

### DIFF
--- a/docs/_components/index.md
+++ b/docs/_components/index.md
@@ -1,0 +1,4 @@
+---
+permalink: /components/
+redirect_to: /components/accordions/
+---

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -1,6 +1,6 @@
 primary:
   - href: /brand/
-  - href: /components/accordions/
+  - href: /components/
     text: Components
   - href: /security-experience-principles/
     text: Security Experience Principles

--- a/docs/_plugins/generate_nav_for_components.rb
+++ b/docs/_plugins/generate_nav_for_components.rb
@@ -2,8 +2,8 @@ require 'json'
 
 Jekyll::Hooks.register :site, :post_read do |site|
   site.collections.each do |name, collection|
-    site.data['nav'][name] = collection.docs.map do |doc|
-      { 'href' => doc.url }
-    end
+    site.data['nav'][name] = collection.docs.
+      filter { |doc| doc.basename != 'index.md'}.
+      map { |doc| { 'href' => doc.url } }
   end
 end


### PR DESCRIPTION
**Why**: Since its sensible that the top-level path is available at its index base, and to resolve a 404 from [the IdP's frontend documentation](https://github.com/18F/identity-idp/blob/main/docs/frontend.md) ([related discussion](https://github.com/18F/identity-idp/pull/7037#discussion_r982459507)).