### PR TITLE
Migrate Federalist to Cloud.gov Pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ OUTPUT_DIR = ./dist
 PACKAGE_DIR = ./build
 NODE_BIN = ./node_modules/.bin
 
-# Federalist builds overwrite the output directory.
+# Cloud.gov Pages builds overwrite the output directory.
 ifdef SITE_PREFIX
 	OUTPUT_DIR = ./_site
 endif

--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@ A failure of this status check only indicates that a visual change was detected.
 
 ## Deploying documentation updates
 
-Documentation deploys are performed automatically upon merging to `main` by [Federalist](https://federalist.18f.gov/). Federalist performs the following steps:
+Documentation deploys are performed automatically upon merging to `main` by [Cloud.gov Pages](https://cloud.gov/pages/). Cloud.gov Pages performs the following steps:
 
 - `npm install --production` (a no-op, as this package has no production dependencies)
-- `npm run federalist`
+- `npm run pages`
 - `bundle install`
 - `bundle exec jekyll build`
 
-More information can be found in Federalist’s [How Builds Work](https://federalist-docs.18f.gov/pages/how-federalist-works/how-builds-work/).
+More information can be found in Cloud.gov Pages' [How Builds Work](https://cloud.gov/pages/documentation/how-builds-work/).
 
 ## Releases
 

--- a/docs/_plugins/site_url.rb
+++ b/docs/_plugins/site_url.rb
@@ -1,9 +1,9 @@
-FEDERALIST_PREVIEW_BRANCH_PREFIX = '/preview/'
+CLOUD_GOV_PAGES_PREVIEW_BRANCH_PREFIX = '/preview/'
 
 Jekyll::Hooks.register :site, :after_init do |site|
   if ENV['BRANCH'].nil? && ENV['JEKYLL_ENV'] != 'production'
     site.config['url'] = "http://localhost:#{site.config['port']}"
-  elsif ENV['BASEURL']&.start_with?(FEDERALIST_PREVIEW_BRANCH_PREFIX)
+  elsif ENV['BASEURL']&.start_with?(CLOUD_GOV_PAGES_PREVIEW_BRANCH_PREFIX)
     # We don't have enough information to reconstruct the URL for the preview site. Setting to `nil`
     # at least allows redirects to work correctly. Sitemap URLs will be invalid, but since preview
     # sites aren't intended to be indexed, this is tolerable.

--- a/docs/_plugins/warn_without_make.rb
+++ b/docs/_plugins/warn_without_make.rb
@@ -1,8 +1,8 @@
 RUNNING_IN_MAKE = !!ENV['MAKEFLAGS'].freeze
-IS_FEDERALIST_BUILD = !!ENV['SITE_PREFIX'].freeze
+IS_CLOUD_GOV_PAGES_BUILD = !!ENV['SITE_PREFIX'].freeze
 
 Jekyll::Hooks.register :site, :after_init do |site|
-  if !RUNNING_IN_MAKE && !IS_FEDERALIST_BUILD
+  if !RUNNING_IN_MAKE && !IS_CLOUD_GOV_PAGES_BUILD
     warn <<~MSG
 
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lint": "gulp lint",
     "test": "make test",
     "build": "make build",
-    "federalist": "make build-assets",
+    "pages": "make build-assets",
     "prepublishOnly": "make lint && make clean && make build-assets build-package"
   },
   "files": [


### PR DESCRIPTION
**Why**: [Federalist is becoming Cloud.gov Pages](https://cloud.gov/pages/federalist-migration/), and as such we'll need to update configurations accordingly.

The webhook settings have already been updated, so these changes are updating documentation and code references to Federalist.