### PR TITLE
Add "Big" variant of Text Input, Textarea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Improvements
 
-- Update Text Input styling to adhere to design specification.
+- Add new "Big" variants of Text Input and Textarea components. ([#326](https://github.com/18F/identity-style-guide/pull/326))
+- Update Text Input styling to adhere to design specification. ([#325](https://github.com/18F/identity-style-guide/pull/325))
 
 ## 6.5.0
 

--- a/docs/_components/form-fields.md
+++ b/docs/_components/form-fields.md
@@ -1,8 +1,10 @@
 ---
 title: Form fields
 subnav:
-  - text: Text
-    href: "#text"
+  - text: Text Input
+    href: "#text-input"
+  - text: Textarea
+    href: "#textarea"
   - text: Dates
     href: "#dates"
   - text: Dropdowns

--- a/docs/_components/form-fields.md
+++ b/docs/_components/form-fields.md
@@ -19,7 +19,9 @@ subnav:
 
 {% include helpers/base-component.html component="form-controls" stylesheet="inputs" %}
 
-## Text
+### Text Input
+
+#### Default
 
 {% capture example %}
 <label for="fd85" class="usa-label">Text input</label>
@@ -27,9 +29,29 @@ subnav:
 {% endcapture %}
 {% include helpers/code-example.html code=example %}
 
+#### Big
+
+{% capture example %}
+<label for="tlkx" class="usa-label">Text input</label>
+<input id="tlkx" type="text" class="usa-input usa-input--big">
+{% endcapture %}
+{% include helpers/code-example.html code=example %}
+
+### Textarea
+
+#### Default
+
 {% capture example %}
 <label for="e8c5" class="usa-label">Textarea (multiline) input</label>
 <textarea id="e8c5" type="text" class="usa-textarea"></textarea>
+{% endcapture %}
+{% include helpers/code-example.html code=example %}
+
+#### Big
+
+{% capture example %}
+<label for="p8n0" class="usa-label">Textarea (multiline) input</label>
+<textarea id="p8n0" type="text" class="usa-textarea usa-textarea--big"></textarea>
 {% endcapture %}
 {% include helpers/code-example.html code=example %}
 

--- a/src/scss/elements/form-controls/_all.scss
+++ b/src/scss/elements/form-controls/_all.scss
@@ -1,1 +1,2 @@
 @import 'global';
+@import 'text-input';

--- a/src/scss/elements/form-controls/_text-input.scss
+++ b/src/scss/elements/form-controls/_text-input.scss
@@ -1,0 +1,14 @@
+.usa-input--big,
+.usa-textarea--big {
+  font-size: units(2.5);
+  line-height: 1.5;
+}
+
+.usa-input--big {
+  @include u-padding-x(2);
+  height: auto;
+}
+
+.usa-textarea--big {
+  height: 15rem;
+}


### PR DESCRIPTION
Adds new "Big" variants of Text Input and Textarea components to reflect Figma LGDS reference, and to support migration toward design system inputs in the IdP.

Live preview: https://federalist-2f194a10-945e-4413-be01-46ca6dae5358.sites.pages.cloud.gov/preview/18f/identity-style-guide/aduth-big-text-inputs/components/form-fields/