### PR TITLE
Add Big variant of Dropdown component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Improvements
+
+- Add new "Big" variant of Dropdown component. ([#328](https://github.com/18F/identity-style-guide/pull/328))
+
 ## 6.6.0
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 6.7.0
 
 ### Improvements
 

--- a/docs/_components/form-fields.md
+++ b/docs/_components/form-fields.md
@@ -96,9 +96,24 @@ Three text fields are the easiest way for users to enter most dates.
 
 ## Dropdowns
 
+### Default
+
 {% capture example %}
 <label for="ab84" class="usa-label">Dropdown label</label>
 <select id="ab84" class="usa-select">
+  <option value>- Select -</option>
+  <option value="value1">Option A</option>
+  <option value="value2">Option B</option>
+  <option value="value3">Option C</option>
+</select>
+{% endcapture %}
+{% include helpers/code-example.html code=example %}
+
+### Big
+
+{% capture example %}
+<label for="vg01" class="usa-label">Dropdown label</label>
+<select id="vg01" class="usa-select usa-select--big">
   <option value>- Select -</option>
   <option value="value1">Option A</option>
   <option value="value2">Option B</option>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "identity-style-guide",
-  "version": "6.6.0",
+  "version": "6.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "identity-style-guide",
-      "version": "6.6.0",
+      "version": "6.7.0",
       "license": "CC0-1.0",
       "dependencies": {
         "domready": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "identity-style-guide",
-  "version": "6.6.0",
+  "version": "6.7.0",
   "description": "The global style of Login.gov",
   "main": "./build/cjs/index.js",
   "module": "./build/esm/index.js",

--- a/src/scss/elements/form-controls/_all.scss
+++ b/src/scss/elements/form-controls/_all.scss
@@ -1,2 +1,3 @@
+@import 'dropdown';
 @import 'global';
 @import 'text-input';

--- a/src/scss/elements/form-controls/_dropdown.scss
+++ b/src/scss/elements/form-controls/_dropdown.scss
@@ -1,0 +1,6 @@
+.usa-select.usa-select--big {
+  @include u-padding-x(2);
+  height: auto;
+  font-size: 1.25rem;
+  line-height: 1.5;
+}

--- a/src/scss/elements/form-controls/_text-input.scss
+++ b/src/scss/elements/form-controls/_text-input.scss
@@ -1,14 +1,14 @@
-.usa-input--big,
-.usa-textarea--big {
+.usa-input.usa-input--big,
+.usa-textarea.usa-textarea--big {
   font-size: units(2.5);
   line-height: 1.5;
 }
 
-.usa-input--big {
+.usa-input.usa-input--big {
   @include u-padding-x(2);
   height: auto;
 }
 
-.usa-textarea--big {
+.usa-textarea.usa-textarea--big {
   height: 15rem;
 }


### PR DESCRIPTION
As part of IdP migration to design system fields, missed in #326 / v6.6.0.

Live preview: https://federalist-2f194a10-945e-4413-be01-46ca6dae5358.sites.pages.cloud.gov/preview/18f/identity-style-guide/aduth-big-select/components/form-fields/#dropdowns

Related discussion: https://docs.google.com/document/d/1CXbI0ji8SUMVqXccoDGZgEkJ5gsoPUpNZUN8MRB0oTs/edit?disco=AAAAl-0lStw