### PR TITLE
Bump version for beta release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@18f/identity-design-system",
-  "version": "6.7.0",
+  "version": "7.0.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@18f/identity-design-system",
-      "version": "6.7.0",
+      "version": "7.0.0-beta.1",
       "license": "CC0-1.0",
       "dependencies": {
         "@uswds/uswds": "^3.4.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@18f/identity-design-system",
-  "version": "6.7.0",
+  "version": "7.0.0-beta.1",
   "description": "The global style of Login.gov",
   "main": "./build/cjs/index.js",
   "module": "./build/esm/index.js",


### PR DESCRIPTION
So we can do some more thorough testing of the new release in a deployed environment for the IdP, prior to an official release.

Versioning follows SemVer: https://semver.org/#spec-item-9