### PR TITLE
Limit size of published Sass content

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ build: build-docs build-assets build-package
 build-docs:
 	JEKYLL_ENV=production bundle exec jekyll build
 
-build-assets: build-sass-and-js build-fonts build-images copy-scss build-sass-packages
+build-assets: build-sass-and-js build-fonts build-images build-sass-packages
 
 build-package:
 	$(NODE_BIN)/gulp build-package
@@ -69,13 +69,6 @@ build-images:
 	mkdir -p $(OUTPUT_DIR)/assets/img
 	cp -r node_modules/@uswds/uswds/dist/img $(OUTPUT_DIR)/assets
 	cp -r src/img $(OUTPUT_DIR)/assets
-
-copy-uswds-scss:
-	mkdir -p $(OUTPUT_DIR)/assets/scss/uswds-packages
-	cp -r node_modules/@uswds/uswds/packages/* $(OUTPUT_DIR)/assets/scss/uswds-packages
-
-copy-scss: copy-uswds-scss
-	$(NODE_BIN)/gulp copy-scss
 
 test: build
 	npm exec jest

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,7 +5,6 @@ const gulp = require('gulp');
 const notify = require('gulp-notify');
 const postcss = require('gulp-postcss');
 const rename = require('gulp-rename');
-const gulpif = require('gulp-if');
 const sass = require('gulp-sass')(require('sass-embedded'));
 const stylelint = require('stylelint');
 const sourcemaps = require('gulp-sourcemaps');
@@ -29,7 +28,6 @@ const OUTPUT_DIR = process.env.OUTPUT_DIR || './dist';
 const PACKAGE_DEST = 'build';
 const JS_DEST = `${OUTPUT_DIR}/assets/js`;
 const CSS_DEST = `${OUTPUT_DIR}/assets/css`;
-const SCSS_DEST = `${OUTPUT_DIR}/assets/scss`;
 
 const notificationOptions = {
   success: {
@@ -151,17 +149,6 @@ gulp.task('build-sass', () =>
 gulp.task('watch-sass', () =>
   gulp.watch(`${PROJECT_SASS_SRC}/**/*.scss`, gulp.series('build-sass')),
 );
-
-const underscorePrefix = () => gulpif((f) => f.basename[0] !== '_', rename({ prefix: '_' }));
-
-gulp.task('copy-login-scss', () =>
-  gulp
-    .src([`${PROJECT_SASS_SRC}/**/*.scss`])
-    .pipe(underscorePrefix())
-    .pipe(gulp.dest(SCSS_DEST)),
-);
-
-gulp.task('copy-scss', gulp.series('copy-login-scss'));
 
 gulp.task('lint', gulp.parallel('lint-js', 'lint-sass'));
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "fast-glob": "^3.2.12",
         "gulp": "^4.0.2",
         "gulp-babel": "^8.0.0",
-        "gulp-if": "^3.0.0",
         "gulp-notify": "^4.0.0",
         "gulp-postcss": "^9.0.1",
         "gulp-rename": "^2.0.0",
@@ -7937,12 +7936,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/fork-stream": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/fork-stream/-/fork-stream-0.0.4.tgz",
-      "integrity": "sha1-24Sfznf2cIpfjzhq5TOgkHtUrnA=",
-      "dev": true
-    },
     "node_modules/form-data": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -8416,36 +8409,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/gulp-if": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-3.0.0.tgz",
-      "integrity": "sha512-fCUEngzNiEZEK2YuPm+sdMpO6ukb8+/qzbGfJBXyNOXz85bCG7yBI+pPSl+N90d7gnLvMsarthsAImx0qy7BAw==",
-      "dev": true,
-      "dependencies": {
-        "gulp-match": "^1.1.0",
-        "ternary-stream": "^3.0.0",
-        "through2": "^3.0.1"
-      }
-    },
-    "node_modules/gulp-if/node_modules/through2": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
-      "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "readable-stream": "2 || 3"
-      }
-    },
-    "node_modules/gulp-match": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.1.0.tgz",
-      "integrity": "sha512-DlyVxa1Gj24DitY2OjEsS+X6tDpretuxD6wTfhXE/Rw2hweqc1f6D/XtsJmoiCwLWfXgR87W9ozEityPCVzGtQ==",
-      "dev": true,
-      "dependencies": {
-        "minimatch": "^3.0.3"
       }
     },
     "node_modules/gulp-notify": {
@@ -16280,54 +16243,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/ternary-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-3.0.0.tgz",
-      "integrity": "sha512-oIzdi+UL/JdktkT+7KU5tSIQjj8pbShj3OASuvDEhm0NT5lppsm7aXWAmAq4/QMaBIyfuEcNLbAQA+HpaISobQ==",
-      "dev": true,
-      "dependencies": {
-        "duplexify": "^4.1.1",
-        "fork-stream": "^0.0.4",
-        "merge-stream": "^2.0.0",
-        "through2": "^3.0.1"
-      }
-    },
-    "node_modules/ternary-stream/node_modules/duplexify": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
-      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
-      "dev": true,
-      "dependencies": {
-        "end-of-stream": "^1.4.1",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1",
-        "stream-shift": "^1.0.0"
-      }
-    },
-    "node_modules/ternary-stream/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/ternary-stream/node_modules/through2": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
-      "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "readable-stream": "2 || 3"
-      }
-    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -23248,12 +23163,6 @@
         "for-in": "^1.0.1"
       }
     },
-    "fork-stream": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/fork-stream/-/fork-stream-0.0.4.tgz",
-      "integrity": "sha1-24Sfznf2cIpfjzhq5TOgkHtUrnA=",
-      "dev": true
-    },
     "form-data": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -23609,38 +23518,6 @@
         "semver-greatest-satisfied-range": "^1.1.0",
         "v8flags": "^3.2.0",
         "yargs": "^7.1.0"
-      }
-    },
-    "gulp-if": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-3.0.0.tgz",
-      "integrity": "sha512-fCUEngzNiEZEK2YuPm+sdMpO6ukb8+/qzbGfJBXyNOXz85bCG7yBI+pPSl+N90d7gnLvMsarthsAImx0qy7BAw==",
-      "dev": true,
-      "requires": {
-        "gulp-match": "^1.1.0",
-        "ternary-stream": "^3.0.0",
-        "through2": "^3.0.1"
-      },
-      "dependencies": {
-        "through2": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
-          "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.4",
-            "readable-stream": "2 || 3"
-          }
-        }
-      }
-    },
-    "gulp-match": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.1.0.tgz",
-      "integrity": "sha512-DlyVxa1Gj24DitY2OjEsS+X6tDpretuxD6wTfhXE/Rw2hweqc1f6D/XtsJmoiCwLWfXgR87W9ozEityPCVzGtQ==",
-      "dev": true,
-      "requires": {
-        "minimatch": "^3.0.3"
       }
     },
     "gulp-notify": {
@@ -29514,53 +29391,6 @@
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
             "util-deprecate": "^1.0.1"
-          }
-        }
-      }
-    },
-    "ternary-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-3.0.0.tgz",
-      "integrity": "sha512-oIzdi+UL/JdktkT+7KU5tSIQjj8pbShj3OASuvDEhm0NT5lppsm7aXWAmAq4/QMaBIyfuEcNLbAQA+HpaISobQ==",
-      "dev": true,
-      "requires": {
-        "duplexify": "^4.1.1",
-        "fork-stream": "^0.0.4",
-        "merge-stream": "^2.0.0",
-        "through2": "^3.0.1"
-      },
-      "dependencies": {
-        "duplexify": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
-          "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
-          "dev": true,
-          "requires": {
-            "end-of-stream": "^1.4.1",
-            "inherits": "^2.0.3",
-            "readable-stream": "^3.1.1",
-            "stream-shift": "^1.0.0"
-          }
-        },
-        "readable-stream": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
-        "through2": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
-          "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.4",
-            "readable-stream": "2 || 3"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
   "files": [
     "build",
     "dist/assets/**/*",
-    "packages"
+    "packages",
+    "!node_modules"
   ],
   "repository": {
     "type": "git",
@@ -76,7 +77,6 @@
     "fast-glob": "^3.2.12",
     "gulp": "^4.0.2",
     "gulp-babel": "^8.0.0",
-    "gulp-if": "^3.0.0",
     "gulp-notify": "^4.0.0",
     "gulp-postcss": "^9.0.1",
     "gulp-rename": "^2.0.0",


### PR DESCRIPTION
Why? So that the package isn't exceedingly large or include files that are not necessary.

Previously, we would copy Sass files from `src/assets/scss` to `dist/assets/scss`, but with the updated usage recommending to use the `packages/` entrypoint (see README.md), the `dist/assets/scss` directory is not necessary.

Additionally, when running `npm publish --dry-run`, I was seeing that there was some `node_modules` files being included, which turns out to be an upstream issue for USWDS (see https://github.com/uswds/uswds/pull/5245). I've excluded them here as well.