### PR TITLE
Fix screenshot regression tests

### DIFF
--- a/test/screenshot.test.js
+++ b/test/screenshot.test.js
@@ -38,7 +38,7 @@ async function toggleHiddenContent() {
 }
 
 async function getScreenshot(url) {
-  await page.goto(url);
+  await page.goto(url, { waitUntil: 'networkidle0' });
   await Promise.all([stubAnimations(), toggleHiddenContent()]);
   return page.screenshot({ fullPage: true });
 }


### PR DESCRIPTION
Fixes an issue where visual regression tests are failing due to an issue introduced with the upgrade of dependencies, including Puppeteer. See https://github.com/18F/identity-style-guide/pull/339#issuecomment-1513335517 for more context, where the issue continued into subsequent pull requests (#342, for example).

This was just a guess at a solution to try to wait until the page load was more "stable" before taking the screenshot, but it appears to be working on first pass.

Related documentation: https://pptr.dev/api/puppeteer.page.goto/#remarks