### PR TITLE
Move global elements styles to elements package

### DIFF
--- a/src/scss/packages/_uswds-elements.scss
+++ b/src/scss/packages/_uswds-elements.scss
@@ -1,0 +1,7 @@
+@use 'uswds-core' as *;
+@forward './uswds-elements/index';
+
+// Overscroll background color to match header and footer
+html {
+  background-color: color('primary-darker');
+}

--- a/src/scss/packages/_uswds.scss
+++ b/src/scss/packages/_uswds.scss
@@ -1,5 +1,3 @@
-@use 'uswds-core' as *;
-
 // Global
 // -------------------------------------
 @forward 'uswds-global';
@@ -56,8 +54,3 @@
 // Utilities
 // -------------------------------------
 @forward 'uswds-utilities';
-
-// Overscroll background color to match header and footer
-html {
-  background-color: color('primary-darker');
-}


### PR DESCRIPTION
**Why?**

- It's an appropriate location for these styles, since [the upstream package](https://github.com/uswds/uswds/tree/develop/packages/uswds-elements/src/styles) contains these sorts of global HTML element styles
- It makes it easier to override the `uswds` package as [documented in the README](https://github.com/18F/identity-style-guide#optimization), since otherwise the style needs to be repeated wherever individual components are being forwarded ([see IdP integration example](https://github.com/18F/identity-idp/commit/c53dff89f93752b280ff00e3d105d7707a9a64bf))