### PR TITLE
Fix alert padding and border radius (USWDS 3 upgrade regression)

### DIFF
--- a/src/scss/packages/_usa-alert.scss
+++ b/src/scss/packages/_usa-alert.scss
@@ -3,20 +3,20 @@
 
 $alerts: 'success', 'warning', 'error', 'info', 'emergency';
 
-.usa-alert__body {
-  @include u-padding-x($theme-alert-padding-x); // See: https://github.com/uswds/uswds/issues/5252}
-}
-
 .usa-alert {
   &,
   & .usa-alert__body {
     border-radius: radius('lg');
   }
 
-  .usa-alert__body::before {
-    background-color: transparent;
-    background-position: center;
-    mask: none;
+  .usa-alert__body {
+    @include u-padding-x($theme-alert-padding-x); // See: https://github.com/uswds/uswds/issues/5252
+
+    &::before {
+      background-color: transparent;
+      background-position: center;
+      mask: none;
+    }
   }
 }
 

--- a/src/scss/packages/_usa-alert.scss
+++ b/src/scss/packages/_usa-alert.scss
@@ -3,8 +3,15 @@
 
 $alerts: 'success', 'warning', 'error', 'info', 'emergency';
 
+.usa-alert__body {
+  @include u-padding-x($theme-alert-padding-x); // See: https://github.com/uswds/uswds/issues/5252}
+}
+
 .usa-alert {
-  border-radius: radius('lg');
+  &,
+  & .usa-alert__body {
+    border-radius: radius('lg');
+  }
 
   .usa-alert__body::before {
     background-color: transparent;


### PR DESCRIPTION
Why?

- USWDS upgrade regressed two intended styles:
  - Overriding horizontal padding
  - Setting border radius on the alert

Before|After
---|---
![image](https://user-images.githubusercontent.com/1779930/234110807-93cd727c-c733-4f1b-993f-5260c2bed9a5.png)|![image](https://user-images.githubusercontent.com/1779930/234110835-454f6833-3b4d-4cf4-8d0d-a51a81ddebf9.png)
