### PR TITLE
Fix links for base component information

### DIFF
--- a/docs/_components/accordions.md
+++ b/docs/_components/accordions.md
@@ -4,7 +4,7 @@ lead: >
   Accordions are a list of headers that can be clicked to hide or reveal additional content.
 ---
 
-{% include helpers/base-component.html component="accordion" stylesheet="accordions" %}
+{% include helpers/base-component.html component="accordion" %}
 
 Before using an accordion, consider if their use would hinder usability. If there is not enough content to warrant condensing or if visitors need to see most or all of the information on a page, use well-formatted text instead.
 

--- a/docs/_components/alerts.md
+++ b/docs/_components/alerts.md
@@ -7,7 +7,7 @@ subnav:
     href: "#types-of-alerts"
 ---
 
-{% include helpers/base-component.html component="alert" stylesheet="alerts" %}
+{% include helpers/base-component.html component="alert" %}
 
 ## Alert Usage
 

--- a/docs/_components/buttons.md
+++ b/docs/_components/buttons.md
@@ -9,7 +9,7 @@ subnav:
     href: "#button-widths"
 ---
 
-{% include helpers/base-component.html component="button" stylesheet="buttons" %}
+{% include helpers/base-component.html component="button" %}
 
 ## Button sizes and states
 

--- a/docs/_components/form-fields.md
+++ b/docs/_components/form-fields.md
@@ -19,7 +19,7 @@ subnav:
     href: "#form-validation-errors"
 ---
 
-{% include helpers/base-component.html component="form-controls" stylesheet="inputs" %}
+{% include helpers/base-component.html component="form-controls" stylesheet="uswds-form-controls" %}
 
 ### Text Input
 

--- a/docs/_components/process-list.md
+++ b/docs/_components/process-list.md
@@ -3,7 +3,7 @@ title: Process List
 lead: A process list displays the steps or stages of important instructions or processes.
 ---
 
-{% include helpers/base-component.html component="process-list" stylesheet="process-list" %}
+{% include helpers/base-component.html component="process-list" %}
 
 ## Default
 

--- a/docs/_components/side-navigation.md
+++ b/docs/_components/side-navigation.md
@@ -4,7 +4,7 @@ lead: >
   Hierarchical, vertical navigation to place at the side of a page. This should correspond to other headers on the page.
 ---
 
-{% include helpers/base-component.html component="side-navigation" stylesheet="sidenav" %}
+{% include helpers/base-component.html component="side-navigation" stylesheet="usa-sidenav" %}
 ## Single level
 {% capture example %}
 <nav aria-label="Secondary navigation" class="tablet:grid-col-4">
@@ -36,7 +36,7 @@ lead: >
         </li>
         <li class="usa-sidenav__item">
           <a href="">Child link</a>
-        </li>           
+        </li>
       </ul>
     </li>
     <li class="usa-sidenav__item usa-parent">
@@ -63,12 +63,12 @@ lead: >
         </li>
         <li class="usa-sidenav__item">
           <a href="">Grandchild link</a>
-        </li>           
+        </li>
       </ul>
         </li>
         <li class="usa-sidenav__item">
           <a href="">Child link</a>
-        </li>           
+        </li>
       </ul>
     </li>
     <li class="usa-sidenav__item usa-parent">

--- a/docs/_includes/helpers/base-component.html
+++ b/docs/_includes/helpers/base-component.html
@@ -1,6 +1,9 @@
-{% assign stylesheet = include.stylesheet | default: include.component %}
+{% assign stylesheet = include.stylesheet %}
+{% unless stylesheet %}
+  {% assign stylesheet = include.component | prepend: 'usa-' %}
+{% endunless %}
 {% assign uswds_url = include.component | append: '/' | prepend: 'https://designsystem.digital.gov/components/' %}
-{% assign sass_url = stylesheet | append: '.scss' | prepend: 'https://github.com/18F/identity-style-guide/blob/main/src/scss/components/_' %}
+{% assign sass_url = stylesheet | append: '.scss' | prepend: 'https://github.com/18F/identity-style-guide/blob/main/src/scss/packages/_' %}
 
 [View USWDS component for guidance]({{ uswds_url }}){: .usa-link--external}
 


### PR DESCRIPTION
Since the folder structure and file naming conventions changed in the USWDS v3 upgrade, these were previously 404-ing in many cases.

![image](https://user-images.githubusercontent.com/1779930/234990978-29718ebf-77ff-460e-8c87-cc69ab9bf6f0.png)

**Testing Instructions:**

Confirm in the preview "Components" pages that "View USWDS component for guidance" and "View Login.gov SCSS on GitHub" links don't 404.